### PR TITLE
docs(ARCHITECTURE.md): add missing analyst agent to agent reads table

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -346,6 +346,7 @@ The information flow is strictly forward — no agent reads output from a later 
 |-------|---------------------|
 | situation-analyst | request.md |
 | investigator | request.md, analysis.md |
+| analyst (Phase 1+2 merged, lite flow template) | request.md |
 | architect | request.md, analysis.md, investigation.md (+review-design.md on revision) — _investigation.md is optional: absent only if phase-2 was unexpectedly skipped for a non-docs flow; proceed without it_ |
 | design-reviewer | request.md, analysis.md, investigation.md, design.md |
 | task-decomposer | request.md, design.md, investigation.md (+review-tasks.md on revision) |


### PR DESCRIPTION
## Summary
- Adds the missing `analyst` agent row to the "What Each Agent Reads" table in `ARCHITECTURE.md`
- The `analyst` agent (merged Phase 1+2, used in the `lite` flow template) was not documented
- No other changes — the "Final Summary" row was already present

## Changes
- `ARCHITECTURE.md`: +1 row for `analyst` agent (reads `request.md`, writes `analysis.md` + `investigation.md`)

## Test plan
- [x] `bash scripts/test-hooks.sh` — 222 passed, 0 failed

---
Generated by [claude-forge](https://github.com/hiromaily/claude-forge/)