### PR TITLE
feat(skill): add Closes #issue to PR body for GitHub issue sources

### DIFF
--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -1246,7 +1246,7 @@ Create a pull request for the feature branch:
    | Rejected push (non-fast-forward) | Exit non-zero AND error message contains `rejected`, `non-fast-forward`, `Updates were rejected` | Call `$SM phase-fail {workspace} pr-creation "git push rejected: non-fast-forward"`. Report to user with the full push error output. Ask the user whether to force-push (`git push --force-with-lease`) or investigate the branch divergence. Do not proceed automatically. |
    | Any other push failure | Exit non-zero AND does not match the above | Call `$SM phase-fail {workspace} pr-creation "git push failed: <error summary>"`. Report the full error output to the user and halt. |
 
-3. **Create the pull request** using `gh pr create`. Derive the title from `request.md` (short, under 70 chars). Build the body from `design.md` and `tasks.md`:
+3. **Create the pull request** using `gh pr create`. Derive the title from `request.md` (short, under 70 chars). Build the body from `design.md` and `tasks.md`. If `source_type` is `github_issue`, include `Closes #<source_id>` in the body so GitHub automatically closes the issue when the PR is merged:
    ```bash
    gh pr create --title "<title>" --body "$(cat <<'EOF'
    ## Summary
@@ -1257,6 +1257,9 @@ Create a pull request for the feature branch:
 
    ## Test plan
    <from design.md test strategy section>
+
+   <Only when source_type is github_issue:>
+   Closes #<source_id>
 
    ---
    Source: <source_url from request.md, if applicable>


### PR DESCRIPTION
## Summary
- When the pipeline input is a GitHub issue URL, the generated PR body now includes `Closes #<source_id>`
- GitHub will automatically close the source issue when the PR is merged
- Instruction is placed before the `---` footer separator, consistent with GitHub conventions

## Changes
- `skills/forge/SKILL.md`: updated step 3 of PR Creation phase with prose note and conditional `Closes #<source_id>` line in the PR body template

## Test plan
- [ ] Run forge with a GitHub issue URL as input and verify the created PR body contains `Closes #<issue_number>`
- [ ] Run forge with plain text input and verify no `Closes #` line appears in the PR body

Closes #14

---
Generated by [claude-forge](https://github.com/hiromaily/claude-forge/)