### PR TITLE
docs: reframe documentation around MCP-first premise

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ The pipeline is built on three core principles:
 
 1. **Files are the API** — Each phase writes a markdown artifact to `.specs/{date}-{name}/`. The next phase reads those files, never the conversation history. This keeps every agent's context small and focused.
 2. **State on disk** — All progress is tracked in `state.json`, so pipelines survive context compaction and session restarts. Hooks read this state to enforce constraints.
-3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, checkpoint gates) that hold regardless of the LLM's behavior.
+3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation, and checkpoint gating. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, session stop guards) that hold regardless of the LLM's behavior.
 
 For the full data flow, state machine, hook architecture, agent input/output matrix, and concurrency model, browse [`docs/architecture/`](./docs/architecture) directly.
 
@@ -24,7 +24,7 @@ A Go MCP server (`forge-state-mcp`) owns all pipeline logic — which phase runs
 User → SKILL.md (LLM executes) → Go Engine (decides next phase) → MCP tools (state + guards)
 ```
 
-1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `exec`, `write_file`, or `done`
+1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `human_gate`, `exec`, `write_file`, or `done`
 2. Execute the action
 3. Call `pipeline_report_result` — Engine advances state
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,56 +8,50 @@ The pipeline is built on three core principles:
 
 1. **Files are the API** — Each phase writes a markdown artifact to `.specs/{date}-{name}/`. The next phase reads those files, never the conversation history. This keeps every agent's context small and focused.
 2. **State on disk** — All progress is tracked in `state.json`, so pipelines survive context compaction and session restarts. Hooks read this state to enforce constraints.
-3. **Two-layer compliance** — Critical invariants (read-only analysis, no parallel commits, checkpoint gates) are enforced both by agent instructions (probabilistic) and hook scripts (deterministic, fail-open).
+3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, checkpoint gates) that hold regardless of the LLM's behavior.
 
 For the full data flow, state machine, hook architecture, agent input/output matrix, and concurrency model, browse [`docs/architecture/`](./docs/architecture) directly.
 
 ---
 
-## Architecture: MCP-driven pipeline engine (v2)
+## Architecture: MCP-driven pipeline engine
 
-claude-forge v1 used shell scripts (`state-manager.sh`) for state management and relied on SKILL.md prompt instructions for all orchestration decisions — which phase to run next, whether to retry, when to skip. The LLM was both the executor *and* the decision-maker.
+claude-forge's defining design principle: the LLM is the **executor**, not the decision-maker.
 
-v2 replaced this with a Go MCP server (`forge-state-mcp`) that owns all pipeline logic. The LLM orchestrator now follows a strict **ask → execute → report** loop: it calls `pipeline_next_action` to get the next action, executes it, and calls `pipeline_report_result` to advance state. It never decides what to do next.
-
-### The shift: LLM as executor, not decision-maker
+A Go MCP server (`forge-state-mcp`) owns all pipeline logic — which phase runs next, whether to retry, when to skip, and what to validate. The LLM orchestrator follows a strict **ask → execute → report** loop:
 
 ```
-v1: User → SKILL.md (LLM decides next phase) → shell scripts (state I/O)
-v2: User → SKILL.md (LLM executes actions)  → Go Engine (decides next phase) → MCP tools (state + guards)
+User → SKILL.md (LLM executes) → Go Engine (decides next phase) → MCP tools (state + guards)
 ```
 
-In v1, if the LLM misinterpreted a skip condition or forgot to call `phase-complete`, the pipeline broke silently. In v2, the Engine returns a typed action (`spawn_agent`, `checkpoint`, `exec`, `write_file`, `done`) — the LLM cannot invent steps or skip them.
+1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `exec`, `write_file`, or `done`
+2. Execute the action
+3. Call `pipeline_report_result` — Engine advances state
 
-### Comparison
-
-| Aspect | v1 (Skill + shell scripts) | v2 (MCP Engine) |
-| --- | --- | --- |
-| **Who decides the next phase** | LLM interprets SKILL.md instructions | `Engine.NextAction()` in Go — deterministic |
-| **State management** | Shell script (`state-manager.sh`) with `jq` | Go `StateManager` with typed fields and mutex locking |
-| **Guard enforcement** | Shell hooks only (exit 2) | Two-layer: Go MCP handler guards + shell hooks |
-| **Phase transition reliability** | Probabilistic — LLM may skip or misordering | Deterministic — Engine enforces canonical PHASES order |
-| **Retry / revision logic** | SKILL.md prose ("if REVISE, re-run Phase 3") | Engine tracks `designRevisions`, `taskRevisions`, `implRetries` with hard limits |
-| **Artifact validation** | None — LLM checks file existence ad-hoc | `validation/artifact.go` — content rules per phase, blocking |
-| **Parallel task dispatch** | SKILL.md instructions + hook blocking | Engine returns `parallel_task_ids`; hook blocks git commit |
-| **Auto-approve logic** | SKILL.md conditional ("if --auto and APPROVE…") | Engine evaluates `autoApprove` + verdict + findings deterministically |
-| **Skip-phase computation** | LLM reads effort table and calls skip-phase | `SkipsForEffort()` returns canonical skip list |
-| **Resume** | LLM reads state.json and figures out where it was | `pipeline_next_action` reads state and returns the exact next step |
-| **Analytics** | None | `analytics.Collector`, `Estimator`, `Reporter` — token/cost/duration tracking |
-| **Cross-pipeline learning** | None | `history.HistoryIndex` (BM25), `KnowledgeBase` (patterns, friction) |
-| **Repo profiling** | None | `profile.RepoProfiler` — language, CI, linter detection for prompt enrichment |
-| **Tool count** | ~10 shell commands | 44 typed MCP tools |
-| **Error handling** | Shell exit codes, often swallowed | Go errors with typed responses (`IsError=true`) |
+The Engine returns typed actions. The LLM cannot invent steps or skip them. If a phase transition condition isn't met — artifact missing, review verdict REVISE, retry limit reached — the Engine enforces it, not a prompt instruction.
 
 ### What this means in practice
 
-**Fewer pipeline failures.** v1's most common failure mode was the LLM misinterpreting a phase transition — skipping a checkpoint, forgetting to call `phase-complete`, or miscounting retry attempts. v2 eliminates this entire class of errors because the Engine makes all transition decisions.
+**Deterministic phase transitions.** Every pipeline decision is a deterministic function of `state.json`. The Engine enforces canonical phase order, tracks revision counts with hard limits, and validates artifacts before advancing. Any pipeline's control flow is reproducible by replaying `NextAction()` calls against saved state.
 
-**Cheaper retries.** When a v1 pipeline stalled, resuming required the LLM to re-read state.json and reconstruct its understanding of where it was. v2's `pipeline_next_action` returns the exact next step — no interpretation needed.
+**Reliable resume.** `pipeline_next_action` returns the exact next step after any interruption — context compaction, session restart, or manual pause. No re-interpretation needed.
 
-**Richer context for agents.** v2 injects historical data (past review patterns, similar implementations, repo profile) into agent prompts via MCP tools. v1 agents worked in isolation with no cross-pipeline knowledge.
+**Cross-pipeline knowledge.** The MCP server injects historical data into agent prompts — past review patterns, similar implementations, repo profile. Agents are informed by every prior run, not just the current session.
 
-**Auditable decisions.** Every Engine decision is a deterministic function of `state.json`. You can reproduce any pipeline's control flow by replaying `NextAction()` calls against the saved state — something impossible with v1's LLM-driven decisions.
+**Auditable decisions.** Every control-flow decision is logged in `state.json` — what ran, what was skipped, retry counts, timestamps. Fully traceable without digging into conversation history.
+
+### MCP tool surface
+
+The `forge-state` server exposes **44 typed MCP tools** across six categories:
+
+| Category | Examples |
+| --- | --- |
+| Lifecycle | `pipeline_init`, `pipeline_next_action`, `pipeline_report_result` |
+| Phase | `phase_start`, `phase_complete`, `phase_fail`, `skip_phase` |
+| Validation | `validate_input`, `validate_artifact` |
+| History | `history_search`, `history_get_patterns`, `history_get_friction_map` |
+| Analytics | `analytics_pipeline_summary`, `analytics_repo_dashboard`, `analytics_estimate` |
+| Code analysis | `ast_summary`, `ast_find_definition`, `dependency_graph`, `impact_scope` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -205,12 +205,12 @@ claude-forge removes phase-transition decisions from the LLM entirely. A Go engi
 
 This determinism runs at two layers:
 
-**Engine layer (MCP)** — all transition decisions are deterministic functions of `state.json`. Phase sequencing, artifact validation, retry limits, review verdict handling — none of it is subject to LLM interpretation.
+**Engine layer (MCP)** — all transition decisions are deterministic functions of `state.json`. Phase sequencing, artifact validation, retry limits, review verdict handling, and checkpoint gating — none of it is subject to LLM interpretation.
 
 **Hook layer (shell)** — critical invariants enforced at the OS level:
 - **Read-only guard** — blocks source edits during analysis phases (exit 2)
 - **Commit guard** — prevents git commits during parallel task execution
-- **Checkpoint gate** — blocks progression until human approval is recorded
+- **Stop guard** — prevents session termination while a pipeline is in progress (exit 2)
 
 Neither layer depends on the LLM following instructions. They're hard stops.
 
@@ -514,7 +514,7 @@ The pipeline is built on three core principles:
 
 1. **Files are the API** — Each phase writes a markdown artifact to `.specs/{date}-{name}/`. The next phase reads those files, never the conversation history. This keeps every agent's context small and focused.
 2. **State on disk** — All progress is tracked in `state.json`, so pipelines survive context compaction and session restarts. Hooks read this state to enforce constraints.
-3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, checkpoint gates) that hold regardless of the LLM's behavior.
+3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation, and checkpoint gating. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, session stop guards) that hold regardless of the LLM's behavior.
 
 For the full data flow, state machine, hook architecture, agent input/output matrix, and concurrency model, browse [`docs/architecture/`](./docs/architecture) directly.
 
@@ -605,7 +605,7 @@ A Go MCP server (`forge-state-mcp`) owns all pipeline logic — which phase runs
 User → SKILL.md (LLM executes) → Go Engine (decides next phase) → MCP tools (state + guards)
 ```
 
-1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `exec`, `write_file`, or `done`
+1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `human_gate`, `exec`, `write_file`, or `done`
 2. Execute the action
 3. Call `pipeline_report_result` — Engine advances state
 

--- a/README.md
+++ b/README.md
@@ -197,17 +197,22 @@ claude-forge selects the pipeline template based on effort level (S / M / L) —
 
 A small task doesn't go through task review. A large one doesn't skip it. The workflow adapts to the effort, not the other way around.
 
-### 4. Deterministic guardrails — hooks, not just prompts
+### 4. MCP-driven determinism — engine and hooks, not just prompts
 
 LLM instructions are probabilistic. A well-prompted agent *usually* follows them. But "usually" isn't enough when the cost of a mistake is high.
 
-claude-forge enforces critical constraints at the shell level via Claude Code hooks:
+claude-forge removes phase-transition decisions from the LLM entirely. A Go engine (`forge-state-mcp`) owns all orchestration logic: which phase runs next, retry counts, skip conditions, artifact validation. The LLM executes typed actions returned by the engine — it cannot invent steps or skip them.
 
+This determinism runs at two layers:
+
+**Engine layer (MCP)** — all transition decisions are deterministic functions of `state.json`. Phase sequencing, artifact validation, retry limits, review verdict handling — none of it is subject to LLM interpretation.
+
+**Hook layer (shell)** — critical invariants enforced at the OS level:
 - **Read-only guard** — blocks source edits during analysis phases (exit 2)
 - **Commit guard** — prevents git commits during parallel task execution
-- **Checkpoint gate** — blocks progression until required artifacts exist and human approval is recorded
+- **Checkpoint gate** — blocks progression until human approval is recorded
 
-These aren't instructions the agent can misinterpret. They're hard stops.
+Neither layer depends on the LLM following instructions. They're hard stops.
 
 ---
 
@@ -509,7 +514,7 @@ The pipeline is built on three core principles:
 
 1. **Files are the API** — Each phase writes a markdown artifact to `.specs/{date}-{name}/`. The next phase reads those files, never the conversation history. This keeps every agent's context small and focused.
 2. **State on disk** — All progress is tracked in `state.json`, so pipelines survive context compaction and session restarts. Hooks read this state to enforce constraints.
-3. **Two-layer compliance** — Critical invariants (read-only analysis, no parallel commits, checkpoint gates) are enforced both by agent instructions (probabilistic) and hook scripts (deterministic, fail-open).
+3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, checkpoint gates) that hold regardless of the LLM's behavior.
 
 For the full data flow, state machine, hook architecture, agent input/output matrix, and concurrency model, browse [`docs/architecture/`](./docs/architecture) directly.
 
@@ -590,49 +595,43 @@ go test -race ./...
 
 The hook test suite covers all hook scripts (`pre-tool-hook.sh`, `post-agent-hook.sh`, `stop-hook.sh`, `post-bash-hook.sh`, `common.sh`), pre-tool-hook rules (read-only, commit blocking, main/master checkout block), and edge cases like abandoned pipelines and special characters in spec names. The Go test suite covers all 26 state-management commands and MCP-only tools.
 
-## Architecture: MCP-driven pipeline engine (v2)
+## Architecture: MCP-driven pipeline engine
 
-claude-forge v1 used shell scripts (`state-manager.sh`) for state management and relied on SKILL.md prompt instructions for all orchestration decisions — which phase to run next, whether to retry, when to skip. The LLM was both the executor *and* the decision-maker.
+claude-forge's defining design principle: the LLM is the **executor**, not the decision-maker.
 
-v2 replaced this with a Go MCP server (`forge-state-mcp`) that owns all pipeline logic. The LLM orchestrator now follows a strict **ask → execute → report** loop: it calls `pipeline_next_action` to get the next action, executes it, and calls `pipeline_report_result` to advance state. It never decides what to do next.
-
-### The shift: LLM as executor, not decision-maker
+A Go MCP server (`forge-state-mcp`) owns all pipeline logic — which phase runs next, whether to retry, when to skip, and what to validate. The LLM orchestrator follows a strict **ask → execute → report** loop:
 
 ```
-v1: User → SKILL.md (LLM decides next phase) → shell scripts (state I/O)
-v2: User → SKILL.md (LLM executes actions)  → Go Engine (decides next phase) → MCP tools (state + guards)
+User → SKILL.md (LLM executes) → Go Engine (decides next phase) → MCP tools (state + guards)
 ```
 
-In v1, if the LLM misinterpreted a skip condition or forgot to call `phase-complete`, the pipeline broke silently. In v2, the Engine returns a typed action (`spawn_agent`, `checkpoint`, `exec`, `write_file`, `done`) — the LLM cannot invent steps or skip them.
+1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `exec`, `write_file`, or `done`
+2. Execute the action
+3. Call `pipeline_report_result` — Engine advances state
 
-### Comparison
-
-| Aspect | v1 (Skill + shell scripts) | v2 (MCP Engine) |
-| --- | --- | --- |
-| **Who decides the next phase** | LLM interprets SKILL.md instructions | `Engine.NextAction()` in Go — deterministic |
-| **State management** | Shell script (`state-manager.sh`) with `jq` | Go `StateManager` with typed fields and mutex locking |
-| **Guard enforcement** | Shell hooks only (exit 2) | Two-layer: Go MCP handler guards + shell hooks |
-| **Phase transition reliability** | Probabilistic — LLM may skip or misordering | Deterministic — Engine enforces canonical PHASES order |
-| **Retry / revision logic** | SKILL.md prose ("if REVISE, re-run Phase 3") | Engine tracks `designRevisions`, `taskRevisions`, `implRetries` with hard limits |
-| **Artifact validation** | None — LLM checks file existence ad-hoc | `validation/artifact.go` — content rules per phase, blocking |
-| **Parallel task dispatch** | SKILL.md instructions + hook blocking | Engine returns `parallel_task_ids`; hook blocks git commit |
-| **Auto-approve logic** | SKILL.md conditional ("if --auto and APPROVE…") | Engine evaluates `autoApprove` + verdict + findings deterministically |
-| **Skip-phase computation** | LLM reads effort table and calls skip-phase | `SkipsForEffort()` returns canonical skip list |
-| **Resume** | LLM reads state.json and figures out where it was | `pipeline_next_action` reads state and returns the exact next step |
-| **Analytics** | None | `analytics.Collector`, `Estimator`, `Reporter` — token/cost/duration tracking |
-| **Cross-pipeline learning** | None | `history.HistoryIndex` (BM25), `KnowledgeBase` (patterns, friction) |
-| **Repo profiling** | None | `profile.RepoProfiler` — language, CI, linter detection for prompt enrichment |
-| **Tool count** | ~10 shell commands | 44 typed MCP tools |
-| **Error handling** | Shell exit codes, often swallowed | Go errors with typed responses (`IsError=true`) |
+The Engine returns typed actions. The LLM cannot invent steps or skip them. If a phase transition condition isn't met — artifact missing, review verdict REVISE, retry limit reached — the Engine enforces it, not a prompt instruction.
 
 ### What this means in practice
 
-**Fewer pipeline failures.** v1's most common failure mode was the LLM misinterpreting a phase transition — skipping a checkpoint, forgetting to call `phase-complete`, or miscounting retry attempts. v2 eliminates this entire class of errors because the Engine makes all transition decisions.
+**Deterministic phase transitions.** Every pipeline decision is a deterministic function of `state.json`. The Engine enforces canonical phase order, tracks revision counts with hard limits, and validates artifacts before advancing. Any pipeline's control flow is reproducible by replaying `NextAction()` calls against saved state.
 
-**Cheaper retries.** When a v1 pipeline stalled, resuming required the LLM to re-read state.json and reconstruct its understanding of where it was. v2's `pipeline_next_action` returns the exact next step — no interpretation needed.
+**Reliable resume.** `pipeline_next_action` returns the exact next step after any interruption — context compaction, session restart, or manual pause. No re-interpretation needed.
 
-**Richer context for agents.** v2 injects historical data (past review patterns, similar implementations, repo profile) into agent prompts via MCP tools. v1 agents worked in isolation with no cross-pipeline knowledge.
+**Cross-pipeline knowledge.** The MCP server injects historical data into agent prompts — past review patterns, similar implementations, repo profile. Agents are informed by every prior run, not just the current session.
 
-**Auditable decisions.** Every Engine decision is a deterministic function of `state.json`. You can reproduce any pipeline's control flow by replaying `NextAction()` calls against the saved state — something impossible with v1's LLM-driven decisions.
+**Auditable decisions.** Every control-flow decision is logged in `state.json` — what ran, what was skipped, retry counts, timestamps. Fully traceable without digging into conversation history.
+
+### MCP tool surface
+
+The `forge-state` server exposes **44 typed MCP tools** across six categories:
+
+| Category | Examples |
+| --- | --- |
+| Lifecycle | `pipeline_init`, `pipeline_next_action`, `pipeline_report_result` |
+| Phase | `phase_start`, `phase_complete`, `phase_fail`, `skip_phase` |
+| Validation | `validate_input`, `validate_artifact` |
+| History | `history_search`, `history_get_patterns`, `history_get_friction_map` |
+| Analytics | `analytics_pipeline_summary`, `analytics_repo_dashboard`, `analytics_estimate` |
+| Code analysis | `ast_summary`, `ast_find_definition`, `dependency_graph`, `impact_scope` |
 
 ---

--- a/template/INDEX.md
+++ b/template/INDEX.md
@@ -29,10 +29,10 @@
 | sections/architecture/how-it-works.md | ARCHITECTURE, README |
 | sections/architecture/how-the-pieces-connect.md | ARCHITECTURE, CLAUDE |
 | sections/architecture/human-interaction.md | ARCHITECTURE, README |
+| sections/architecture/mcp-driven-pipeline-control.md | ARCHITECTURE, README |
 | sections/architecture/pipeline-flow.md | ARCHITECTURE, README |
 | sections/architecture/pipeline-phase-execution-by-effort-level.md | ARCHITECTURE, README |
 | sections/architecture/pipeline-phase-table.md | ARCHITECTURE, README |
-| sections/architecture/why-mcp-driven-pipeline-control-v2-vs-v1.md | ARCHITECTURE, README |
 | sections/development/before-you-start-working.md | CLAUDE |
 | sections/development/consistency-requirements.md | CLAUDE |
 | sections/development/development-constraints.md | CLAUDE |
@@ -103,6 +103,7 @@
 | sections/architecture/runtime-flow.md | Not referenced by any template |
 | sections/architecture/state-management.md | Not referenced by any template |
 | sections/architecture/technical-decisions.md | Not referenced by any template |
+| sections/architecture/why-mcp-driven-pipeline-control-v2-vs-v1.md | Not referenced by any template |
 | sections/ja/agents/architect.md | Not referenced by any template |
 | sections/ja/agents/comprehensive-reviewer.md | Not referenced by any template |
 | sections/ja/agents/design-reviewer.md | Not referenced by any template |

--- a/template/pages/ARCHITECTURE.tpl.md
+++ b/template/pages/ARCHITECTURE.tpl.md
@@ -4,7 +4,7 @@
 
 <!-- @include: ../sections/architecture/how-it-works.md -->
 
-<!-- @include: ../sections/architecture/why-mcp-driven-pipeline-control-v2-vs-v1.md -->
+<!-- @include: ../sections/architecture/mcp-driven-pipeline-control.md -->
 
 <!-- @include: ../sections/architecture/how-the-pieces-connect.md -->
 

--- a/template/pages/README.tpl.md
+++ b/template/pages/README.tpl.md
@@ -36,4 +36,4 @@ Source: template/pages/README.tpl.md · Run `make docs` to regenerate.
 
 <!-- @include: ../sections/development/running-tests.md -->
 
-<!-- @include: ../sections/architecture/why-mcp-driven-pipeline-control-v2-vs-v1.md -->
+<!-- @include: ../sections/architecture/mcp-driven-pipeline-control.md -->

--- a/template/sections/architecture/how-it-works.md
+++ b/template/sections/architecture/how-it-works.md
@@ -4,7 +4,7 @@ The pipeline is built on three core principles:
 
 1. **Files are the API** — Each phase writes a markdown artifact to `.specs/{date}-{name}/`. The next phase reads those files, never the conversation history. This keeps every agent's context small and focused.
 2. **State on disk** — All progress is tracked in `state.json`, so pipelines survive context compaction and session restarts. Hooks read this state to enforce constraints.
-3. **Two-layer compliance** — Critical invariants (read-only analysis, no parallel commits, checkpoint gates) are enforced both by agent instructions (probabilistic) and hook scripts (deterministic, fail-open).
+3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, checkpoint gates) that hold regardless of the LLM's behavior.
 
 For the full data flow, state machine, hook architecture, agent input/output matrix, and concurrency model, browse [`docs/architecture/`](../../../docs/architecture/) directly.
 

--- a/template/sections/architecture/how-it-works.md
+++ b/template/sections/architecture/how-it-works.md
@@ -4,7 +4,7 @@ The pipeline is built on three core principles:
 
 1. **Files are the API** — Each phase writes a markdown artifact to `.specs/{date}-{name}/`. The next phase reads those files, never the conversation history. This keeps every agent's context small and focused.
 2. **State on disk** — All progress is tracked in `state.json`, so pipelines survive context compaction and session restarts. Hooks read this state to enforce constraints.
-3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, checkpoint gates) that hold regardless of the LLM's behavior.
+3. **Engine-driven control** — The Go MCP server (`forge-state-mcp`) owns all orchestration decisions: which phase runs next, skip conditions, retry limits, artifact validation, and checkpoint gating. The LLM follows typed actions returned by `pipeline_next_action` — it cannot invent or skip steps. Shell hooks enforce a complementary set of OS-level invariants (read-only analysis, no parallel commits, session stop guards) that hold regardless of the LLM's behavior.
 
 For the full data flow, state machine, hook architecture, agent input/output matrix, and concurrency model, browse [`docs/architecture/`](../../../docs/architecture/) directly.
 

--- a/template/sections/architecture/mcp-driven-pipeline-control.md
+++ b/template/sections/architecture/mcp-driven-pipeline-control.md
@@ -1,0 +1,40 @@
+## Architecture: MCP-driven pipeline engine
+
+claude-forge's defining design principle: the LLM is the **executor**, not the decision-maker.
+
+A Go MCP server (`forge-state-mcp`) owns all pipeline logic — which phase runs next, whether to retry, when to skip, and what to validate. The LLM orchestrator follows a strict **ask → execute → report** loop:
+
+```
+User → SKILL.md (LLM executes) → Go Engine (decides next phase) → MCP tools (state + guards)
+```
+
+1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `exec`, `write_file`, or `done`
+2. Execute the action
+3. Call `pipeline_report_result` — Engine advances state
+
+The Engine returns typed actions. The LLM cannot invent steps or skip them. If a phase transition condition isn't met — artifact missing, review verdict REVISE, retry limit reached — the Engine enforces it, not a prompt instruction.
+
+### What this means in practice
+
+**Deterministic phase transitions.** Every pipeline decision is a deterministic function of `state.json`. The Engine enforces canonical phase order, tracks revision counts with hard limits, and validates artifacts before advancing. Any pipeline's control flow is reproducible by replaying `NextAction()` calls against saved state.
+
+**Reliable resume.** `pipeline_next_action` returns the exact next step after any interruption — context compaction, session restart, or manual pause. No re-interpretation needed.
+
+**Cross-pipeline knowledge.** The MCP server injects historical data into agent prompts — past review patterns, similar implementations, repo profile. Agents are informed by every prior run, not just the current session.
+
+**Auditable decisions.** Every control-flow decision is logged in `state.json` — what ran, what was skipped, retry counts, timestamps. Fully traceable without digging into conversation history.
+
+### MCP tool surface
+
+The `forge-state` server exposes **44 typed MCP tools** across six categories:
+
+| Category | Examples |
+| --- | --- |
+| Lifecycle | `pipeline_init`, `pipeline_next_action`, `pipeline_report_result` |
+| Phase | `phase_start`, `phase_complete`, `phase_fail`, `skip_phase` |
+| Validation | `validate_input`, `validate_artifact` |
+| History | `history_search`, `history_get_patterns`, `history_get_friction_map` |
+| Analytics | `analytics_pipeline_summary`, `analytics_repo_dashboard`, `analytics_estimate` |
+| Code analysis | `ast_summary`, `ast_find_definition`, `dependency_graph`, `impact_scope` |
+
+---

--- a/template/sections/architecture/mcp-driven-pipeline-control.md
+++ b/template/sections/architecture/mcp-driven-pipeline-control.md
@@ -8,7 +8,7 @@ A Go MCP server (`forge-state-mcp`) owns all pipeline logic — which phase runs
 User → SKILL.md (LLM executes) → Go Engine (decides next phase) → MCP tools (state + guards)
 ```
 
-1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `exec`, `write_file`, or `done`
+1. Call `pipeline_next_action` — receive a typed action: `spawn_agent`, `checkpoint`, `human_gate`, `exec`, `write_file`, or `done`
 2. Execute the action
 3. Call `pipeline_report_result` — Engine advances state
 

--- a/template/sections/product/four-things-that-make-it-different.md
+++ b/template/sections/product/four-things-that-make-it-different.md
@@ -44,12 +44,12 @@ claude-forge removes phase-transition decisions from the LLM entirely. A Go engi
 
 This determinism runs at two layers:
 
-**Engine layer (MCP)** — all transition decisions are deterministic functions of `state.json`. Phase sequencing, artifact validation, retry limits, review verdict handling — none of it is subject to LLM interpretation.
+**Engine layer (MCP)** — all transition decisions are deterministic functions of `state.json`. Phase sequencing, artifact validation, retry limits, review verdict handling, and checkpoint gating — none of it is subject to LLM interpretation.
 
 **Hook layer (shell)** — critical invariants enforced at the OS level:
 - **Read-only guard** — blocks source edits during analysis phases (exit 2)
 - **Commit guard** — prevents git commits during parallel task execution
-- **Checkpoint gate** — blocks progression until human approval is recorded
+- **Stop guard** — prevents session termination while a pipeline is in progress (exit 2)
 
 Neither layer depends on the LLM following instructions. They're hard stops.
 

--- a/template/sections/product/four-things-that-make-it-different.md
+++ b/template/sections/product/four-things-that-make-it-different.md
@@ -36,16 +36,21 @@ claude-forge selects the pipeline template based on effort level (S / M / L) —
 
 A small task doesn't go through task review. A large one doesn't skip it. The workflow adapts to the effort, not the other way around.
 
-### 4. Deterministic guardrails — hooks, not just prompts
+### 4. MCP-driven determinism — engine and hooks, not just prompts
 
 LLM instructions are probabilistic. A well-prompted agent *usually* follows them. But "usually" isn't enough when the cost of a mistake is high.
 
-claude-forge enforces critical constraints at the shell level via Claude Code hooks:
+claude-forge removes phase-transition decisions from the LLM entirely. A Go engine (`forge-state-mcp`) owns all orchestration logic: which phase runs next, retry counts, skip conditions, artifact validation. The LLM executes typed actions returned by the engine — it cannot invent steps or skip them.
 
+This determinism runs at two layers:
+
+**Engine layer (MCP)** — all transition decisions are deterministic functions of `state.json`. Phase sequencing, artifact validation, retry limits, review verdict handling — none of it is subject to LLM interpretation.
+
+**Hook layer (shell)** — critical invariants enforced at the OS level:
 - **Read-only guard** — blocks source edits during analysis phases (exit 2)
 - **Commit guard** — prevents git commits during parallel task execution
-- **Checkpoint gate** — blocks progression until required artifacts exist and human approval is recorded
+- **Checkpoint gate** — blocks progression until human approval is recorded
 
-These aren't instructions the agent can misinterpret. They're hard stops.
+Neither layer depends on the LLM following instructions. They're hard stops.
 
 ---


### PR DESCRIPTION
## Summary

- Replaces the v1-vs-v2 comparison section with `mcp-driven-pipeline-control.md`: describes the engine in present tense (ask→execute→report loop, typed actions, deterministic transitions, MCP tool surface table) without any historical framing
- Renames `how-it-works.md` principle 3 from "Two-layer compliance (agent instructions + hooks)" to "Engine-driven control" — the MCP server is now named as the primary control layer, with shell hooks described as a complementary layer
- Rewrites `four-things-that-make-it-different.md` item 4 from "Deterministic guardrails — hooks, not just prompts" to "MCP-driven determinism — engine and hooks, not just prompts"; removes internal method names (`Engine.NextAction()`, `validate_artifact`, `designRevisions`, `implRetries`) to keep the section product-level
- All generated outputs (`README.md`, `ARCHITECTURE.md`, etc.) regenerated via `make docs`

## Test plan

- [ ] `make docs-validate` passes (all includes resolve)
- [ ] No `v1`/`v2` comparison prose in `README.md` or `ARCHITECTURE.md` (only factual label `post-bash-hook.sh ← v1 legacy` in directory listing)
- [ ] "How it works" principle 3 names the MCP engine first
- [ ] "Four things" item 4 leads with MCP engine, no internal method names

🤖 Generated with [Claude Code](https://claude.com/claude-code)