### PR TITLE
feat(analytics): add human-readable duration to phase_stats and analytics responses

### DIFF
--- a/mcp-server/internal/analytics/collector.go
+++ b/mcp-server/internal/analytics/collector.go
@@ -3,7 +3,6 @@
 package analytics
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/orchestrator"
@@ -81,7 +80,7 @@ func (c *Collector) Collect(workspace string) (*PipelineSummary, error) {
 		FlowTemplate:     derefString(s.FlowTemplate),
 		TotalTokens:      totalTokens,
 		TotalDurationMs:  totalDurationMs,
-		TotalDuration:    formatDurationMs(totalDurationMs),
+		TotalDuration:    state.FormatDurationMs(totalDurationMs),
 		EstimatedCostUSD: float64(totalTokens) * costPerToken,
 		PhasesExecuted:   phasesExecuted,
 		PhasesSkipped:    phasesSkipped,
@@ -130,20 +129,4 @@ func derefString(s *string) string {
 	}
 
 	return *s
-}
-
-// formatDurationMs formats a duration in milliseconds as a human-readable string.
-// Examples: 0 → "0s", 18000 → "18s", 90000 → "1m 30s", 3661000 → "1h 1m 1s".
-func formatDurationMs(ms int) string {
-	total := ms / 1000
-	h := total / 3600
-	m := (total % 3600) / 60
-	s := total % 60
-	if h > 0 {
-		return fmt.Sprintf("%dh %dm %ds", h, m, s)
-	}
-	if m > 0 {
-		return fmt.Sprintf("%dm %ds", m, s)
-	}
-	return fmt.Sprintf("%ds", s)
 }

--- a/mcp-server/internal/analytics/collector.go
+++ b/mcp-server/internal/analytics/collector.go
@@ -3,6 +3,7 @@
 package analytics
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/orchestrator"
@@ -30,6 +31,7 @@ type PipelineSummary struct {
 	FlowTemplate     string        `json:"flow_template"`
 	TotalTokens      int           `json:"total_tokens"`
 	TotalDurationMs  int           `json:"total_duration_ms"`
+	TotalDuration    string        `json:"total_duration"`
 	EstimatedCostUSD float64       `json:"estimated_cost_usd"`
 	PhasesExecuted   int           `json:"phases_executed"`
 	PhasesSkipped    int           `json:"phases_skipped"`
@@ -79,6 +81,7 @@ func (c *Collector) Collect(workspace string) (*PipelineSummary, error) {
 		FlowTemplate:     derefString(s.FlowTemplate),
 		TotalTokens:      totalTokens,
 		TotalDurationMs:  totalDurationMs,
+		TotalDuration:    formatDurationMs(totalDurationMs),
 		EstimatedCostUSD: float64(totalTokens) * costPerToken,
 		PhasesExecuted:   phasesExecuted,
 		PhasesSkipped:    phasesSkipped,
@@ -127,4 +130,20 @@ func derefString(s *string) string {
 	}
 
 	return *s
+}
+
+// formatDurationMs formats a duration in milliseconds as a human-readable string.
+// Examples: 0 → "0s", 18000 → "18s", 90000 → "1m 30s", 3661000 → "1h 1m 1s".
+func formatDurationMs(ms int) string {
+	total := ms / 1000
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm %ds", h, m, s)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
 }

--- a/mcp-server/internal/analytics/collector_test.go
+++ b/mcp-server/internal/analytics/collector_test.go
@@ -80,6 +80,10 @@ func TestCollect_BasicAggregation(t *testing.T) {
 		t.Errorf("TotalDurationMs = %d, want 18000", summary.TotalDurationMs)
 	}
 
+	if summary.TotalDuration != "18s" {
+		t.Errorf("TotalDuration = %q, want %q", summary.TotalDuration, "18s")
+	}
+
 	wantCost := float64(3500) * 0.000006
 	if summary.EstimatedCostUSD != wantCost {
 		t.Errorf("EstimatedCostUSD = %f, want %f", summary.EstimatedCostUSD, wantCost)
@@ -239,6 +243,10 @@ func TestCollect_EmptyPhaseLog(t *testing.T) {
 
 	if summary.TotalDurationMs != 0 {
 		t.Errorf("TotalDurationMs = %d, want 0", summary.TotalDurationMs)
+	}
+
+	if summary.TotalDuration != "0s" {
+		t.Errorf("TotalDuration = %q, want %q", summary.TotalDuration, "0s")
 	}
 
 	if summary.EstimatedCostUSD != 0 {

--- a/mcp-server/internal/state/manager.go
+++ b/mcp-server/internal/state/manager.go
@@ -1002,6 +1002,7 @@ func (m *StateManager) PhaseLog(workspace, phase string, tokens, durationMs int,
 type PhaseStatsResult struct {
 	TotalTokens     int             `json:"totalTokens"`
 	TotalDurationMs int             `json:"totalDurationMs"`
+	TotalDuration   string          `json:"totalDuration"`
 	Entries         []PhaseLogEntry `json:"entries"`
 }
 
@@ -1025,6 +1026,7 @@ func (m *StateManager) PhaseStats(workspace string) (*PhaseStatsResult, error) {
 		result.TotalTokens += entry.Tokens
 		result.TotalDurationMs += entry.DurationMs
 	}
+	result.TotalDuration = formatDurationMs(result.TotalDurationMs)
 	return result, nil
 }
 
@@ -1175,4 +1177,20 @@ func appendUnique(slice []string, s string) []string {
 		return slice
 	}
 	return append(slice, s)
+}
+
+// formatDurationMs formats a duration in milliseconds as a human-readable string.
+// Examples: 0 → "0s", 18000 → "18s", 90000 → "1m 30s", 3661000 → "1h 1m 1s".
+func formatDurationMs(ms int) string {
+	total := ms / 1000
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm %ds", h, m, s)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%dm %ds", m, s)
+	}
+	return fmt.Sprintf("%ds", s)
 }

--- a/mcp-server/internal/state/manager.go
+++ b/mcp-server/internal/state/manager.go
@@ -1026,7 +1026,7 @@ func (m *StateManager) PhaseStats(workspace string) (*PhaseStatsResult, error) {
 		result.TotalTokens += entry.Tokens
 		result.TotalDurationMs += entry.DurationMs
 	}
-	result.TotalDuration = formatDurationMs(result.TotalDurationMs)
+	result.TotalDuration = FormatDurationMs(result.TotalDurationMs)
 	return result, nil
 }
 
@@ -1179,9 +1179,9 @@ func appendUnique(slice []string, s string) []string {
 	return append(slice, s)
 }
 
-// formatDurationMs formats a duration in milliseconds as a human-readable string.
+// FormatDurationMs formats a duration in milliseconds as a human-readable string.
 // Examples: 0 → "0s", 18000 → "18s", 90000 → "1m 30s", 3661000 → "1h 1m 1s".
-func formatDurationMs(ms int) string {
+func FormatDurationMs(ms int) string {
 	total := ms / 1000
 	h := total / 3600
 	m := (total % 3600) / 60

--- a/mcp-server/internal/state/manager_test.go
+++ b/mcp-server/internal/state/manager_test.go
@@ -1075,6 +1075,9 @@ func TestPhaseStats_EmptyLog_ReturnsZeroes(t *testing.T) {
 	if result.TotalDurationMs != 0 {
 		t.Errorf("totalDurationMs: got %d, want 0", result.TotalDurationMs)
 	}
+	if result.TotalDuration != "0s" {
+		t.Errorf("totalDuration: got %q, want %q", result.TotalDuration, "0s")
+	}
 	if len(result.Entries) != 0 {
 		t.Errorf("entries: got %d, want 0", len(result.Entries))
 	}
@@ -1107,6 +1110,9 @@ func TestPhaseStats_AggregatesCorrectly(t *testing.T) {
 	}
 	if result.TotalDurationMs != 60000 {
 		t.Errorf("totalDurationMs: got %d, want 60000", result.TotalDurationMs)
+	}
+	if result.TotalDuration != "1m 0s" {
+		t.Errorf("totalDuration: got %q, want %q", result.TotalDuration, "1m 0s")
 	}
 	if len(result.Entries) != 3 {
 		t.Errorf("entries count: got %d, want 3", len(result.Entries))


### PR DESCRIPTION
## Summary

- `phase_stats` now returns a `totalDuration` string field (e.g. `"35m 13s"`) alongside the existing raw `totalDurationMs` integer
- `analytics_pipeline_summary` returns the same as `total_duration`
- Format: `Xs` / `Xm Ys` / `Xh Ym Zs` — computed deterministically in Go, not by the LLM

## Motivation

The verifier agent that writes `summary.md` was reporting `Total duration: 2,113,419 ms`, which is hard to read. By providing a pre-formatted field in the MCP response, the agent uses the human-readable value directly — making the fix deterministic rather than relying on the model to convert units.

## Test plan

- [x] `TestPhaseStats_EmptyLog_ReturnsZeroes` — asserts `totalDuration = "0s"`
- [x] `TestPhaseStats_AggregatesCorrectly` — asserts `totalDuration = "1m 0s"` for 60 000 ms
- [x] `TestCollect_*` — asserts `total_duration = "18s"` for 18 000 ms and `"0s"` for empty log
- [x] Full test suite: `go test -race ./...` passes
- [x] Linter: `golangci-lint run` clean (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)