### PR TITLE
fix(orchestrator): increase MaxRevisionRetries from 2 to 5

### DIFF
--- a/mcp-server/internal/orchestrator/engine_test.go
+++ b/mcp-server/internal/orchestrator/engine_test.go
@@ -378,7 +378,7 @@ func TestNextAction(t *testing.T) {
 			setupSM: func(t *testing.T) *state.StateManager {
 				t.Helper()
 				sm := newTestStateManager(t, "phase-3b", func(s *state.State) error {
-					s.Revisions.DesignRevisions = 2
+					s.Revisions.DesignRevisions = state.MaxRevisionRetries
 					return nil
 				})
 				st, err := sm.GetState()
@@ -458,7 +458,7 @@ func TestNextAction(t *testing.T) {
 			setupSM: func(t *testing.T) *state.StateManager {
 				t.Helper()
 				sm := newTestStateManager(t, "phase-4", func(s *state.State) error {
-					s.Revisions.TaskRevisions = 2
+					s.Revisions.TaskRevisions = state.MaxRevisionRetries
 					return nil
 				})
 				st, err := sm.GetState()
@@ -536,7 +536,7 @@ func TestNextAction(t *testing.T) {
 			setupSM: func(t *testing.T) *state.StateManager {
 				t.Helper()
 				sm := newTestStateManager(t, "phase-4b", func(s *state.State) error {
-					s.Revisions.TaskRevisions = 2
+					s.Revisions.TaskRevisions = state.MaxRevisionRetries
 					return nil
 				})
 				st, err := sm.GetState()
@@ -795,7 +795,7 @@ func TestNextAction(t *testing.T) {
 							ExecutionMode: "sequential",
 							ImplStatus:    "completed",
 							ReviewStatus:  state.TaskStatusCompletedFail,
-							ImplRetries:   2,
+							ImplRetries:   state.MaxRevisionRetries,
 						},
 					}
 					return nil

--- a/mcp-server/internal/state/constants.go
+++ b/mcp-server/internal/state/constants.go
@@ -113,7 +113,10 @@ const (
 // ---------- Retry limits ----------
 
 const (
-	MaxRevisionRetries = 2
+	// MaxRevisionRetries is the maximum number of review/revision cycles before
+	// the engine escalates to a human checkpoint. Increase this value to allow
+	// more automated retries before human intervention is required.
+	MaxRevisionRetries = 5
 )
 
 // ---------- Verdict values ----------


### PR DESCRIPTION
## Summary
- Increases `MaxRevisionRetries` from 2 to 5 in `mcp-server/internal/state/constants.go`
- Adds a comment to the constant explaining it controls all review/revision loop limits
- Updates `engine_test.go` to use `state.MaxRevisionRetries` instead of hardcoded `2`, so tests remain correct when the value changes again

## Test plan
- [x] All existing tests pass (`go test -race ./...`)
- [x] No hardcoded `2` values remain in engine tests for limit-checking scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)