### PR TITLE
fix(tools): fix stale-cache bug causing phase-5 to advance prematurely + extract reportResultCore

### DIFF
--- a/.specs/20260412-mcp-server-deterministic-refactor/state.json
+++ b/.specs/20260412-mcp-server-deterministic-refactor/state.json
@@ -1,0 +1,188 @@
+{
+  "version": 2,
+  "forge-state-mcp-version": "v2.8.0",
+  "specName": "mcp-server-deterministic-refactor",
+  "workspace": ".specs/20260412-mcp-server-deterministic-refactor",
+  "branch": "feature/mcp-server-deterministic-refactor",
+  "effort": "L",
+  "flowTemplate": "full",
+  "autoApprove": false,
+  "skipPr": false,
+  "useCurrentBranch": true,
+  "branchClassified": false,
+  "debug": false,
+  "skippedPhases": [],
+  "currentPhase": "completed",
+  "currentPhaseStatus": "completed",
+  "completedPhases": [
+    "setup",
+    "phase-1",
+    "phase-2",
+    "phase-3",
+    "phase-3b",
+    "checkpoint-a",
+    "phase-4",
+    "phase-4b",
+    "checkpoint-b",
+    "phase-5",
+    "phase-7",
+    "final-verification",
+    "pr-creation",
+    "final-summary",
+    "post-to-source",
+    "final-commit"
+  ],
+  "revisions": {
+    "designRevisions": 1,
+    "taskRevisions": 1,
+    "designInlineRevisions": 0,
+    "taskInlineRevisions": 0
+  },
+  "checkpointRevisionPending": {
+    "checkpoint-a": false,
+    "checkpoint-b": false
+  },
+  "needsBatchCommit": false,
+  "tasks": {},
+  "phaseLog": [
+    {
+      "phase": "phase-1",
+      "tokens": 71860,
+      "duration_ms": 244227,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:00:01.169013Z"
+    },
+    {
+      "phase": "phase-2",
+      "tokens": 108518,
+      "duration_ms": 256364,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:04:35.642391Z"
+    },
+    {
+      "phase": "phase-3",
+      "tokens": 77713,
+      "duration_ms": 216135,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:08:34.050721Z"
+    },
+    {
+      "phase": "phase-3b",
+      "tokens": 56883,
+      "duration_ms": 274417,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:13:30.651686Z"
+    },
+    {
+      "phase": "phase-3",
+      "tokens": 52386,
+      "duration_ms": 217485,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:17:42.116592Z"
+    },
+    {
+      "phase": "phase-3",
+      "tokens": 55871,
+      "duration_ms": 231804,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:22:21.36382Z"
+    },
+    {
+      "phase": "phase-3",
+      "tokens": 41846,
+      "duration_ms": 188548,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:26:13.167471Z"
+    },
+    {
+      "phase": "phase-3",
+      "tokens": 39286,
+      "duration_ms": 193090,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:30:24.34813Z"
+    },
+    {
+      "phase": "phase-3b",
+      "tokens": 38797,
+      "duration_ms": 79787,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:33:05.56945Z"
+    },
+    {
+      "phase": "phase-4",
+      "tokens": 34914,
+      "duration_ms": 75310,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:36:43.747787Z"
+    },
+    {
+      "phase": "phase-4b",
+      "tokens": 36070,
+      "duration_ms": 55447,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:37:57.15079Z"
+    },
+    {
+      "phase": "phase-4",
+      "tokens": 27260,
+      "duration_ms": 64349,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:39:21.199706Z"
+    },
+    {
+      "phase": "phase-4b",
+      "tokens": 36784,
+      "duration_ms": 69110,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:40:48.974686Z"
+    },
+    {
+      "phase": "phase-5",
+      "tokens": 58709,
+      "duration_ms": 135914,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:45:45.133125Z"
+    },
+    {
+      "phase": "phase-7",
+      "tokens": 43558,
+      "duration_ms": 46463,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:47:12.847344Z"
+    },
+    {
+      "phase": "final-verification",
+      "tokens": 44592,
+      "duration_ms": 73648,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:49:09.010209Z"
+    },
+    {
+      "phase": "pr-creation",
+      "tokens": 0,
+      "duration_ms": 15000,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:49:36.879993Z"
+    },
+    {
+      "phase": "final-summary",
+      "tokens": 29243,
+      "duration_ms": 84711,
+      "model": "sonnet",
+      "timestamp": "2026-04-11T16:51:45.036995Z"
+    },
+    {
+      "phase": "final-commit",
+      "tokens": 0,
+      "duration_ms": 0,
+      "model": "",
+      "timestamp": "2026-04-11T16:51:46.854399Z"
+    }
+  ],
+  "timestamps": {
+    "created": "2026-04-11T15:55:31.033611Z",
+    "lastUpdated": "2026-04-11T16:51:46.854696Z",
+    "phaseStarted": null
+  },
+  "error": null
+}

--- a/.specs/20260412-mcp-server-deterministic-refactor/summary.md
+++ b/.specs/20260412-mcp-server-deterministic-refactor/summary.md
@@ -1,0 +1,53 @@
+# Summary: mcp-server-deterministic-refactor
+
+## What was done
+
+Task 1 of 9 was implemented: `reportResultCore` was extracted from `handleReportResult` in `mcp-server/internal/tools/pipeline_report_result.go`. The inner response type was renamed from `reportResultResponse` to `reportResultOutcome` throughout the file. `handleReportResult` was reduced to a thin wrapper that calls `reportResultCore` and returns `okJSON(out)`. `PipelineReportResultHandler` was left unchanged. All 13 Go packages pass `go test -race ./...` and all 62 hook tests pass.
+
+This refactor creates the callable `reportResultCore(sm, kb, in) (reportResultOutcome, error)` foundation that Task 2 depends on — enabling `PipelineNextActionHandler` to invoke report-result logic without going through the MCP wire format, which is the core goal of the deterministic 2-call loop design.
+
+## PR
+
+https://github.com/hiromaily/claude-forge/pull/146
+
+Source: https://github.com/hiromaily/claude-forge/issues/145
+
+## Remaining work (Tasks 2–9)
+
+- **Task 2**: Add P5 block to `PipelineNextActionHandler` — define `previousResult`/`reportResultEmbedded` types, add `parsePreviousResult` helper, and call `reportResultCore` when `previous_tokens > 0` or `previous_model != ""` for non-terminal phases.
+- **Task 3**: Register four optional parameters (`previous_tokens`, `previous_duration_ms`, `previous_model`, `previous_setup_only`) on the `pipeline_next_action` tool in `registry.go`.
+- **Task 4**: Add P5 unit tests (three cases: proceed, revision-required, setup-continue) and integration tests in `pipeline_next_action_test.go` and `pipeline_integration_test.go`.
+- **Task 5**: Decompose `pipeline_report_result.go` into `verdict_parser.go`, `phase_transition.go`, and `artifact_guard.go`. Create `verdict_parser_test.go` with direct unit tests.
+- **Task 6**: Decompose `pipeline_init_with_context.go` into `context_fetcher.go` and `workspace_init.go`.
+- **Task 7**: Extract response helpers from `handlers.go` into `response_helpers.go`. `helpers.go` stays unchanged.
+- **Task 8**: Rewrite `skills/forge/SKILL.md` to the 2-call loop — remove `pipeline_report_result` from the main loop.
+- **Task 9**: Full verification pass — `go test -race ./...`, `bash scripts/test-hooks.sh`, `TestRegisterAllCount`.
+
+## Pipeline Statistics
+- Total tokens: 825,047
+- Total duration: 2,437,098 ms (40m 37s)
+- Estimated cost: $4.95
+- Phases executed: 13
+- Phases skipped: 0
+- Retries: 0
+- Review findings: 0 critical, 6 minor
+
+## Improvement Report
+
+_Retrospective on what would have made this work easier._
+
+### Documentation
+
+`analysis.md` and `investigation.md` were not persisted to disk, removing visibility into friction encountered during earlier phases. The design for the 2-call deterministic loop spans three interdependent files (`pipeline_next_action.go`, `registry.go`, `SKILL.md`) with no cross-reference comment in the source tying them together. A short comment block at the top of `pipeline_next_action.go` explaining the intended 2-call contract would reduce discovery burden for future implementers.
+
+### Code Readability
+
+`pipeline_report_result.go` co-locates wire-format parsing, artifact guards, verdict determination, phase transition logic, and response helpers. The `reportResultResponse` → `reportResultOutcome` rename required a grep across the whole `mcp-server/` tree to confirm zero residual references — unnecessary if the original name had more clearly indicated its scope.
+
+### AI Agent Support (Skills / Rules)
+
+The pipeline ran only Task 1 of 9, leaving 8 tasks unimplemented. The orchestrator's task-dispatch logic did not continue to Tasks 2–9 in this run. A `resume` flow or explicit "tasks remaining" warning in the final-summary phase would surface this to the operator earlier. No existing CLAUDE.md rule addresses the pattern of large handler files accumulating multiple concerns; a "single responsibility per file" guideline for `mcp-server/internal/tools/` would better justify decomposition tasks.
+
+### Other
+
+The design revision loop (phase-3 architect repeatedly dispatched instead of phase-3b reviewer) added multiple unnecessary architecture agent runs. The phase-3b `revisionPending` flag was only cleared by re-running the design-reviewer directly, bypassing the engine's returned action. This is a known orchestrator loop bug worth addressing in the MCP server engine logic.

--- a/mcp-server/internal/tools/pipeline_report_result.go
+++ b/mcp-server/internal/tools/pipeline_report_result.go
@@ -113,7 +113,7 @@ func reportResultCore(sm *state.StateManager, kb *history.KnowledgeBase, in repo
 	// Step 2: Load state for duplicate-log check (before PhaseLog).
 	s, err := loadState(in.workspace)
 	if err != nil {
-		return reportResultOutcome{}, fmt.Errorf("read state: %v", err)
+		return reportResultOutcome{}, fmt.Errorf("read state: %w", err)
 	}
 	if w := Warn3dPhaseLogDuplicate(in.phase, s); w != "" {
 		warnings = append(warnings, w)
@@ -121,7 +121,7 @@ func reportResultCore(sm *state.StateManager, kb *history.KnowledgeBase, in repo
 
 	// Step 3: Record phase-log entry.
 	if err := sm.PhaseLog(in.workspace, in.phase, in.tokensUsed, in.durationMs, in.model); err != nil {
-		return reportResultOutcome{}, fmt.Errorf("phase_log: %v", err)
+		return reportResultOutcome{}, fmt.Errorf("phase_log: %w", err)
 	}
 
 	// Step 4: Validate artifacts for this phase.

--- a/mcp-server/internal/tools/pipeline_report_result.go
+++ b/mcp-server/internal/tools/pipeline_report_result.go
@@ -81,6 +81,16 @@ func PipelineReportResultHandler(sm *state.StateManager, kb *history.KnowledgeBa
 			return result, err
 		}
 
+		// Per-call StateManager: load fresh from disk to avoid stale-cache conflicts
+		// with task state written by PipelineNextActionHandler's own per-call sm2
+		// (e.g. executeTaskInit writes tasks via sm2, but the global sm cache predates
+		// that write and would overwrite the tasks on the first sm.Update call).
+		// This mirrors the pattern in PipelineNextActionHandler.
+		sm2 := state.NewStateManager(sm.Version())
+		if loadErr := sm2.LoadFromFile(workspace); loadErr != nil {
+			return errorf("load state: %v", loadErr)
+		}
+
 		in := reportResultInput{
 			workspace:  workspace,
 			phase:      phase,
@@ -90,7 +100,7 @@ func PipelineReportResultHandler(sm *state.StateManager, kb *history.KnowledgeBa
 			setupOnly:  req.GetBool("setup_only", false),
 		}
 
-		return handleReportResult(sm, kb, in)
+		return handleReportResult(sm2, kb, in)
 	}
 }
 

--- a/mcp-server/internal/tools/pipeline_report_result.go
+++ b/mcp-server/internal/tools/pipeline_report_result.go
@@ -44,11 +44,13 @@ var phaseAgentName = map[string]string{
 	"phase-4b": "task-reviewer",
 }
 
-// reportResultResponse is the structured response returned by PipelineReportResultHandler.
+// reportResultOutcome is the typed result of the report-result core logic.
+// It is returned by reportResultCore and consumed by both PipelineReportResultHandler
+// (via handleReportResult) and PipelineNextActionHandler (P5 embedding).
 // DisplayMessage is a pre-formatted completion line the orchestrator should output verbatim
 // after a phase finishes (e.g. "  ✓ Complete  ·  1,847 tokens · 0:23").
 // It is only set when NextActionHint is "proceed" and setup_only is false.
-type reportResultResponse struct {
+type reportResultOutcome struct {
 	StateUpdated    bool                   `json:"state_updated"`
 	ArtifactWritten string                 `json:"artifact_written"`
 	VerdictParsed   string                 `json:"verdict_parsed"`
@@ -92,15 +94,16 @@ func PipelineReportResultHandler(sm *state.StateManager, kb *history.KnowledgeBa
 	}
 }
 
-// handleReportResult performs the core logic of PipelineReportResultHandler.
-// Extracted to a named function for testability.
-func handleReportResult(sm *state.StateManager, kb *history.KnowledgeBase, in reportResultInput) (*mcp.CallToolResult, error) {
+// reportResultCore performs the core report-result logic.
+// Returns a typed outcome for callers that need to inspect NextActionHint
+// without deserializing a JSON wire response.
+func reportResultCore(sm *state.StateManager, kb *history.KnowledgeBase, in reportResultInput) (reportResultOutcome, error) {
 	var warnings []string
 
 	// Step 2: Load state for duplicate-log check (before PhaseLog).
 	s, err := loadState(in.workspace)
 	if err != nil {
-		return errorf("read state: %v", err)
+		return reportResultOutcome{}, fmt.Errorf("read state: %v", err)
 	}
 	if w := Warn3dPhaseLogDuplicate(in.phase, s); w != "" {
 		warnings = append(warnings, w)
@@ -108,7 +111,7 @@ func handleReportResult(sm *state.StateManager, kb *history.KnowledgeBase, in re
 
 	// Step 3: Record phase-log entry.
 	if err := sm.PhaseLog(in.workspace, in.phase, in.tokensUsed, in.durationMs, in.model); err != nil {
-		return errorf("phase_log: %v", err)
+		return reportResultOutcome{}, fmt.Errorf("phase_log: %v", err)
 	}
 
 	// Step 4: Validate artifacts for this phase.
@@ -125,7 +128,7 @@ func handleReportResult(sm *state.StateManager, kb *history.KnowledgeBase, in re
 		// Block only when there is an error string (file missing, no verdict token found).
 		// ParseVerdict is the authoritative mechanism for PASS/FAIL decisions in phase-6.
 		if !result.Valid && result.Error != "" {
-			return errorf("artifact invalid for %s: %s", in.phase, result.Error)
+			return reportResultOutcome{}, fmt.Errorf("artifact invalid for %s: %s", in.phase, result.Error)
 		}
 		// Step 6: Set artifactWritten from the first result with a File field.
 		if i == 0 && result.File != "" {
@@ -134,24 +137,34 @@ func handleReportResult(sm *state.StateManager, kb *history.KnowledgeBase, in re
 	}
 
 	// Steps 7–9: Determine state transition based on phase.
-	resp, err := determineTransition(sm, kb, in, results, artifactWritten, &warnings)
+	out, err := determineTransition(sm, kb, in, results, artifactWritten, &warnings)
 	if err != nil {
-		return errorf("%v", err)
+		return reportResultOutcome{}, err
 	}
 
 	// Merge any warning from the transition handler (e.g. completion gate)
 	// into the accumulated warnings before building the final response.
-	if resp.Warning != "" {
-		warnings = append(warnings, resp.Warning)
+	if out.Warning != "" {
+		warnings = append(warnings, out.Warning)
 	}
-	resp.Warning = strings.Join(warnings, "; ")
+	out.Warning = strings.Join(warnings, "; ")
 
 	// Attach a display message when the phase completed successfully.
-	if resp.NextActionHint == "proceed" && !in.setupOnly {
-		resp.DisplayMessage = buildCompleteMessage(in.tokensUsed, in.durationMs)
+	if out.NextActionHint == "proceed" && !in.setupOnly {
+		out.DisplayMessage = buildCompleteMessage(in.tokensUsed, in.durationMs)
 	}
 
-	return okJSON(resp)
+	return out, nil
+}
+
+// handleReportResult serializes reportResultCore output to the MCP wire format.
+// Retained for backward compatibility with existing tests.
+func handleReportResult(sm *state.StateManager, kb *history.KnowledgeBase, in reportResultInput) (*mcp.CallToolResult, error) {
+	out, err := reportResultCore(sm, kb, in)
+	if err != nil {
+		return errorf("%v", err)
+	}
+	return okJSON(out)
 }
 
 // determineTransition decides the correct state transition and returns a partial response.
@@ -164,16 +177,16 @@ func determineTransition(
 	results []validation.ArtifactResult,
 	artifactWritten string,
 	warnings *[]string,
-) (reportResultResponse, error) {
+) (reportResultOutcome, error) {
 	// Step 7: Review phases (phase-3b, phase-4b) — parse verdict and decide.
 	if revType, ok := phaseRevType[in.phase]; ok {
 		artifactFile, knownFile := reviewArtifactFile[in.phase]
 		if !knownFile {
 			// Fallback: complete the phase without verdict parsing.
 			if err := sm.PhaseComplete(in.workspace, in.phase); err != nil {
-				return reportResultResponse{}, err
+				return reportResultOutcome{}, err
 			}
-			return reportResultResponse{
+			return reportResultOutcome{
 				StateUpdated:    true,
 				ArtifactWritten: artifactWritten,
 				NextActionHint:  "proceed",
@@ -182,7 +195,7 @@ func determineTransition(
 
 		verdict, findings, err := orchestrator.ParseVerdict(filepath.Join(in.workspace, artifactFile))
 		if err != nil {
-			return reportResultResponse{}, err
+			return reportResultOutcome{}, err
 		}
 
 		findings = nonNilSlice(findings)
@@ -196,9 +209,9 @@ func determineTransition(
 		switch verdict {
 		case orchestrator.VerdictRevise:
 			if err := sm.RevisionBump(in.workspace, revType); err != nil {
-				return reportResultResponse{}, err
+				return reportResultOutcome{}, err
 			}
-			return reportResultResponse{
+			return reportResultOutcome{
 				StateUpdated:    true,
 				ArtifactWritten: artifactWritten,
 				VerdictParsed:   string(verdict),
@@ -208,9 +221,9 @@ func determineTransition(
 		default:
 			// APPROVE, APPROVE_WITH_NOTES, or UNKNOWN — all advance the phase.
 			if err := sm.PhaseComplete(in.workspace, in.phase); err != nil {
-				return reportResultResponse{}, err
+				return reportResultOutcome{}, err
 			}
-			return reportResultResponse{
+			return reportResultOutcome{
 				StateUpdated:    true,
 				ArtifactWritten: artifactWritten,
 				VerdictParsed:   string(verdict),
@@ -227,7 +240,7 @@ func determineTransition(
 
 	// Step 9: All other phases — advance unless setup_only.
 	if in.setupOnly {
-		return reportResultResponse{
+		return reportResultOutcome{
 			StateUpdated:    true,
 			ArtifactWritten: artifactWritten,
 			NextActionHint:  "setup_continue",
@@ -264,13 +277,13 @@ func determineTransition(
 			}
 			return nil
 		}); updateErr != nil {
-			return reportResultResponse{}, updateErr
+			return reportResultOutcome{}, updateErr
 		}
 
 		// Re-read state after potential updates.
 		s, err := sm.GetState()
 		if err != nil {
-			return reportResultResponse{}, err
+			return reportResultOutcome{}, err
 		}
 		hasPending := false
 		for _, t := range s.Tasks {
@@ -282,7 +295,7 @@ func determineTransition(
 		// Also hold in phase-5 if a batch commit is pending (e.g. last parallel
 		// batch just completed — all tasks done but git commit not yet run).
 		if hasPending || s.NeedsBatchCommit {
-			return reportResultResponse{
+			return reportResultOutcome{
 				StateUpdated:    true,
 				ArtifactWritten: artifactWritten,
 				NextActionHint:  "setup_continue",
@@ -304,9 +317,9 @@ func determineTransition(
 				}
 				return nil
 			}); updateErr != nil {
-				return reportResultResponse{}, updateErr
+				return reportResultOutcome{}, updateErr
 			}
-			return reportResultResponse{
+			return reportResultOutcome{
 				StateUpdated:    true,
 				ArtifactWritten: artifactWritten,
 				NextActionHint:  "setup_continue",
@@ -317,7 +330,7 @@ func determineTransition(
 		// All tasks complete — clear any completed_fail retry state so the
 		// engine dispatches fresh reviewers after the retry implementer ran.
 		if err := clearCompletedFailTasks(sm, in.workspace); err != nil {
-			return reportResultResponse{}, err
+			return reportResultOutcome{}, err
 		}
 	}
 
@@ -327,16 +340,16 @@ func determineTransition(
 	// task-decomposer with the findings.
 	if in.phase == "phase-4" {
 		if resp, handled, err := applyWorkflowRules(sm, in.workspace, artifactWritten); err != nil {
-			return reportResultResponse{}, err
+			return reportResultOutcome{}, err
 		} else if handled {
 			return resp, nil
 		}
 	}
 
 	if err := sm.PhaseComplete(in.workspace, in.phase); err != nil {
-		return reportResultResponse{}, err
+		return reportResultOutcome{}, err
 	}
-	return reportResultResponse{
+	return reportResultOutcome{
 		StateUpdated:    true,
 		ArtifactWritten: artifactWritten,
 		NextActionHint:  "proceed",
@@ -357,7 +370,7 @@ func handlePhase6Transition(
 	in reportResultInput,
 	results []validation.ArtifactResult,
 	artifactWritten string,
-) (reportResultResponse, error) {
+) (reportResultOutcome, error) {
 	allFindings := []orchestrator.Finding{}
 	var verdictParsed string
 	anyFail := false
@@ -410,9 +423,9 @@ func handlePhase6Transition(
 			}
 			return nil
 		}); updateErr != nil {
-			return reportResultResponse{}, updateErr
+			return reportResultOutcome{}, updateErr
 		}
-		return reportResultResponse{
+		return reportResultOutcome{
 			StateUpdated:    true,
 			ArtifactWritten: artifactWritten,
 			VerdictParsed:   verdictParsed,
@@ -427,7 +440,7 @@ func handlePhase6Transition(
 	// Read verdicts outside the lock to avoid I/O inside a critical section.
 	s, err := sm.GetState()
 	if err != nil {
-		return reportResultResponse{}, err
+		return reportResultOutcome{}, err
 	}
 	type verdictUpdate struct {
 		key    string
@@ -466,14 +479,14 @@ func handlePhase6Transition(
 			}
 			return nil
 		}); updateErr != nil {
-			return reportResultResponse{}, updateErr
+			return reportResultOutcome{}, updateErr
 		}
 	}
 
 	// Check whether any task still needs a review.
 	s, err = sm.GetState()
 	if err != nil {
-		return reportResultResponse{}, err
+		return reportResultOutcome{}, err
 	}
 	for _, t := range s.Tasks {
 		if t.ImplStatus != state.TaskStatusCompleted {
@@ -482,7 +495,7 @@ func handlePhase6Transition(
 		if t.ReviewStatus != state.TaskStatusCompletedPass &&
 			t.ReviewStatus != state.TaskStatusCompletedPassNote {
 			// Task needs review — hold in phase-6.
-			return reportResultResponse{
+			return reportResultOutcome{
 				StateUpdated:    true,
 				ArtifactWritten: artifactWritten,
 				VerdictParsed:   verdictParsed,
@@ -505,9 +518,9 @@ func handlePhase6Transition(
 			}
 			return nil
 		}); updateErr != nil {
-			return reportResultResponse{}, updateErr
+			return reportResultOutcome{}, updateErr
 		}
-		return reportResultResponse{
+		return reportResultOutcome{
 			StateUpdated:    true,
 			ArtifactWritten: artifactWritten,
 			VerdictParsed:   verdictParsed,
@@ -518,9 +531,9 @@ func handlePhase6Transition(
 	}
 
 	if err := sm.PhaseComplete(in.workspace, in.phase); err != nil {
-		return reportResultResponse{}, err
+		return reportResultOutcome{}, err
 	}
-	return reportResultResponse{
+	return reportResultOutcome{
 		StateUpdated:    true,
 		ArtifactWritten: artifactWritten,
 		VerdictParsed:   verdictParsed,
@@ -622,10 +635,10 @@ func clearCompletedFailTasks(sm *state.StateManager, workspace string) error {
 // enforce MaxRevisionRetries on the next pipeline_next_action call. This
 // mirrors how VerdictRevise on phase-4b increments the same counter in
 // determineTransition.
-func applyWorkflowRules(sm *state.StateManager, workspace, artifactWritten string) (reportResultResponse, bool, error) {
+func applyWorkflowRules(sm *state.StateManager, workspace, artifactWritten string) (reportResultOutcome, bool, error) {
 	tasks, rules, reviewPath, ok, err := loadPhase4Context(workspace)
 	if !ok || err != nil {
-		return reportResultResponse{}, false, err
+		return reportResultOutcome{}, false, err
 	}
 
 	violations := validation.Validate(tasks, rules)
@@ -635,14 +648,14 @@ func applyWorkflowRules(sm *state.StateManager, workspace, artifactWritten strin
 		// phase-4b task-reviewer (handlePhaseFourB) writes a fresh file
 		// instead of reading a stale REVISE verdict and looping.
 		if err := os.Remove(reviewPath); err != nil && !os.IsNotExist(err) {
-			return reportResultResponse{}, false, fmt.Errorf("remove stale %s: %w", state.ArtifactReviewTasks, err)
+			return reportResultOutcome{}, false, fmt.Errorf("remove stale %s: %w", state.ArtifactReviewTasks, err)
 		}
-		return reportResultResponse{}, false, nil
+		return reportResultOutcome{}, false, nil
 	}
 
 	resp, err := writeViolationResponse(sm, workspace, reviewPath, artifactWritten, violations)
 	if err != nil {
-		return reportResultResponse{}, false, err
+		return reportResultOutcome{}, false, err
 	}
 	return resp, true, nil
 }
@@ -684,7 +697,7 @@ func loadPhase4Context(workspace string) (map[string]state.Task, *validation.Wor
 }
 
 // writeViolationResponse writes review-tasks.md, bumps TaskRevisions, and
-// builds the reportResultResponse for a workflow-rules violation.
+// builds the reportResultOutcome for a workflow-rules violation.
 //
 // Order matters: write review-tasks.md FIRST, then bump TaskRevisions.
 // If RevisionBump fails, the orchestrator still sees review-tasks.md on
@@ -692,9 +705,9 @@ func loadPhase4Context(workspace string) (map[string]state.Task, *validation.Wor
 // task-decomposer — we just lose one retry-limit tick, which is
 // recoverable. Reversing the order would risk bumping the counter with
 // no findings file on disk, which would waste a retry slot silently.
-func writeViolationResponse(sm *state.StateManager, workspace, reviewPath, artifactWritten string, violations []validation.Violation) (reportResultResponse, error) {
+func writeViolationResponse(sm *state.StateManager, workspace, reviewPath, artifactWritten string, violations []validation.Violation) (reportResultOutcome, error) {
 	if err := os.WriteFile(reviewPath, []byte(validation.FormatReviewFindings(violations)), 0o600); err != nil {
-		return reportResultResponse{}, fmt.Errorf("write %s: %w", state.ArtifactReviewTasks, err)
+		return reportResultOutcome{}, fmt.Errorf("write %s: %w", state.ArtifactReviewTasks, err)
 	}
 
 	// Bump TaskRevisions so handlePhaseFour enforces MaxRevisionRetries on
@@ -702,7 +715,7 @@ func writeViolationResponse(sm *state.StateManager, workspace, reviewPath, artif
 	// bumps the same counter when phase-4b parses a REVISE verdict — keeping
 	// the retry-limit enforcement in one place (the engine).
 	if err := sm.RevisionBump(workspace, state.RevTypeTasks); err != nil {
-		return reportResultResponse{}, fmt.Errorf("revision bump (tasks): %w", err)
+		return reportResultOutcome{}, fmt.Errorf("revision bump (tasks): %w", err)
 	}
 
 	findings := make([]orchestrator.Finding, 0, len(violations))
@@ -714,7 +727,7 @@ func writeViolationResponse(sm *state.StateManager, workspace, reviewPath, artif
 		})
 	}
 
-	return reportResultResponse{
+	return reportResultOutcome{
 		StateUpdated:    true,
 		ArtifactWritten: artifactWritten,
 		VerdictParsed:   "REVISE",

--- a/mcp-server/internal/tools/pipeline_report_result_test.go
+++ b/mcp-server/internal/tools/pipeline_report_result_test.go
@@ -26,12 +26,12 @@ func initPRRWorkspace(t *testing.T, sm *state.StateManager) string {
 	return dir
 }
 
-// parsePRRResponse unmarshals reportResultResponse from a content string.
-func parsePRRResponse(t *testing.T, content string) reportResultResponse {
+// parsePRRResponse unmarshals reportResultOutcome from a content string.
+func parsePRRResponse(t *testing.T, content string) reportResultOutcome {
 	t.Helper()
-	var resp reportResultResponse
+	var resp reportResultOutcome
 	if err := json.Unmarshal([]byte(content), &resp); err != nil {
-		t.Fatalf("unmarshal reportResultResponse: %v (content: %s)", err, content)
+		t.Fatalf("unmarshal reportResultOutcome: %v (content: %s)", err, content)
 	}
 	return resp
 }
@@ -663,7 +663,7 @@ func setupPhase4SpecWorkspace(t *testing.T, specName string) (string, string, *s
 // callPhase4Report invokes PipelineReportResultHandler on phase-4 with a
 // minimal set of parameters and returns the parsed response. Callers must
 // write tasks.md (and any instructions.md) before calling this helper.
-func callPhase4Report(t *testing.T, sm *state.StateManager, workspace string) reportResultResponse {
+func callPhase4Report(t *testing.T, sm *state.StateManager, workspace string) reportResultOutcome {
 	t.Helper()
 	h := PipelineReportResultHandler(sm, history.NewKnowledgeBase(""))
 	res := callTool(t, h, map[string]any{

--- a/mcp-server/internal/tools/pipeline_report_result_test.go
+++ b/mcp-server/internal/tools/pipeline_report_result_test.go
@@ -534,6 +534,61 @@ func TestPipelineReportResult(t *testing.T) {
 			},
 		},
 		{
+			// Regression: stale-cache bug where PipelineReportResultHandler was
+			// passed a global StateManager whose in-memory cache predated the
+			// TaskInit call made inside PipelineNextActionHandler (P2 absorption).
+			// With a stale cache of 0 tasks, the old code called sm.Update (via
+			// PhaseLog) which overwrote disk with 0 tasks, making hasPending=false
+			// and advancing phase-5 prematurely after only 1 task was implemented.
+			// The fix creates a per-call sm2 inside PipelineReportResultHandler so
+			// it always loads fresh state from disk, regardless of the global sm.
+			name:  "phase5_stale_cache_does_not_advance_with_pending_tasks",
+			phase: "phase-5",
+			setup: func(t *testing.T, sm *state.StateManager, dir string) {
+				t.Helper()
+				// Simulate executeTaskInit: write 3 tasks via a *different* StateManager
+				// (sm2), leaving the test's "global" sm with a stale empty cache.
+				sm2 := state.NewStateManager("dev")
+				if err := sm2.LoadFromFile(dir); err != nil {
+					t.Fatalf("sm2.LoadFromFile: %v", err)
+				}
+				tasks := map[string]state.Task{
+					"1": {Title: "Task 1"},
+					"2": {Title: "Task 2"},
+					"3": {Title: "Task 3"},
+				}
+				if err := sm2.TaskInit(dir, tasks); err != nil {
+					t.Fatalf("sm2.TaskInit: %v", err)
+				}
+				// Only impl-1.md exists — tasks 2 and 3 are still pending.
+				if err := os.WriteFile(filepath.Join(dir, "impl-1.md"), []byte("content"), 0o644); err != nil {
+					t.Fatalf("WriteFile impl-1.md: %v", err)
+				}
+				// sm (the "global" handler sm) is NOT updated — its in-memory cache
+				// still has 0 tasks, reproducing the stale-cache scenario.
+			},
+			wantIsError:     false,
+			wantStateUpdate: true,
+			wantHint:        "setup_continue", // must NOT advance to "proceed"
+			checkState: func(t *testing.T, dir string) {
+				t.Helper()
+				s, err := state.ReadState(dir)
+				if err != nil {
+					t.Fatalf("ReadState: %v", err)
+				}
+				// Tasks must survive — the handler must not overwrite with 0 tasks.
+				if len(s.Tasks) != 3 {
+					t.Fatalf("Tasks count = %d after phase-5 report, want 3 (stale cache must not overwrite tasks)", len(s.Tasks))
+				}
+				// phase-5 must NOT be completed.
+				for _, p := range s.CompletedPhases {
+					if p == "phase-5" {
+						t.Error("phase-5 must NOT be in CompletedPhases while tasks 2 and 3 are pending")
+					}
+				}
+			},
+		},
+		{
 			// Phase 6 completion gate: all tasks reviewed (PASS) but review-2.md
 			// missing on disk — must block phase completion and reset ReviewStatus
 			// so the engine re-dispatches reviewers.


### PR DESCRIPTION
## Summary

- **Bug fix**: `PipelineReportResultHandler` was passed the global `sm` whose in-memory cache predated the `TaskInit` call inside `PipelineNextActionHandler`'s `executeTaskInit` (which writes via its own per-call `sm2`). The first `sm.Update` inside `handleReportResult` overwrote disk with the stale 0-task cache, making `hasPending = false` and advancing phase-5 after only 1 task instead of all 9.
- **Fix**: Create a fresh per-call `sm2` at the top of `PipelineReportResultHandler`, mirroring the existing pattern in `PipelineNextActionHandler`.
- **Refactor (Task 1 of hiromaily/claude-forge#145)**: Extract `reportResultCore` from `handleReportResult`, enabling `PipelineNextActionHandler` to invoke report-result logic without going through the MCP wire format — the foundation for the deterministic 2-call loop.

## Test plan

- [x] `go test -race ./...` — all 13 packages pass
- [x] `make go-lint-fast-check` — 0 issues
- [x] Regression test `phase5_stale_cache_does_not_advance_with_pending_tasks` covers the exact bug scenario: tasks written by a separate `sm2`, global `sm` stale — asserts `"setup_continue"` returned and all tasks preserved on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)