### PR TITLE
test(tools): add end-to-end pipeline integration test with mock LLM layer

### DIFF
--- a/.specs/20260412-add-pipeline-e2e-integration-test/state.json
+++ b/.specs/20260412-add-pipeline-e2e-integration-test/state.json
@@ -1,0 +1,152 @@
+{
+  "version": 2,
+  "forge-state-mcp-version": "v2.9.1",
+  "specName": "add-pipeline-e2e-integration-test",
+  "workspace": ".specs/20260412-add-pipeline-e2e-integration-test",
+  "branch": "feature/add-pipeline-e2e-integration-test",
+  "effort": "M",
+  "flowTemplate": "standard",
+  "autoApprove": false,
+  "skipPr": false,
+  "useCurrentBranch": false,
+  "branchClassified": false,
+  "debug": false,
+  "skippedPhases": [
+    "phase-4b",
+    "checkpoint-b"
+  ],
+  "currentPhase": "completed",
+  "currentPhaseStatus": "completed",
+  "completedPhases": [
+    "setup",
+    "checkpoint-a",
+    "phase-4",
+    "phase-4b",
+    "checkpoint-b",
+    "phase-5",
+    "phase-6",
+    "phase-7",
+    "final-verification",
+    "pr-creation",
+    "final-summary",
+    "post-to-source",
+    "final-commit"
+  ],
+  "revisions": {
+    "designRevisions": 0,
+    "taskRevisions": 0,
+    "designInlineRevisions": 0,
+    "taskInlineRevisions": 0
+  },
+  "checkpointRevisionPending": {
+    "checkpoint-a": false,
+    "checkpoint-b": false
+  },
+  "needsBatchCommit": false,
+  "tasks": {
+    "1": {
+      "title": "Implement pipeline_e2e_test.go [sequential]",
+      "executionMode": "sequential",
+      "depends_on": null,
+      "files": [
+        "/Users/hiroki.yasui/work/hiromaily/claude-forge/mcp-server/internal/tools/pipeline_e2e_test.go"
+      ],
+      "implStatus": "completed",
+      "reviewStatus": "completed_pass",
+      "implRetries": 0,
+      "reviewRetries": 0
+    },
+    "2": {
+      "title": "Verify full test suite still passes [sequential]",
+      "executionMode": "sequential",
+      "depends_on": [
+        1
+      ],
+      "files": [
+        "/Users/hiroki.yasui/work/hiromaily/claude-forge/mcp-server/internal/tools/pipeline_e2e_test.go"
+      ],
+      "implStatus": "completed",
+      "reviewStatus": "completed_pass",
+      "implRetries": 0,
+      "reviewRetries": 0
+    }
+  },
+  "phaseLog": [
+    {
+      "phase": "phase-4",
+      "tokens": 42132,
+      "duration_ms": 38763,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T08:57:45.286206Z"
+    },
+    {
+      "phase": "phase-5",
+      "tokens": 97355,
+      "duration_ms": 449074,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T09:05:54.814122Z"
+    },
+    {
+      "phase": "phase-5",
+      "tokens": 22760,
+      "duration_ms": 38595,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T09:06:50.340243Z"
+    },
+    {
+      "phase": "phase-6",
+      "tokens": 36912,
+      "duration_ms": 82661,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T09:08:29.539826Z"
+    },
+    {
+      "phase": "phase-6",
+      "tokens": 22147,
+      "duration_ms": 27124,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T09:09:09.961191Z"
+    },
+    {
+      "phase": "phase-7",
+      "tokens": 44739,
+      "duration_ms": 92540,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T09:10:57.318843Z"
+    },
+    {
+      "phase": "final-verification",
+      "tokens": 44591,
+      "duration_ms": 100813,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T09:12:58.888278Z"
+    },
+    {
+      "phase": "pr-creation",
+      "tokens": 0,
+      "duration_ms": 15000,
+      "model": "",
+      "timestamp": "2026-04-12T09:13:42.573419Z"
+    },
+    {
+      "phase": "final-summary",
+      "tokens": 34412,
+      "duration_ms": 60967,
+      "model": "sonnet",
+      "timestamp": "2026-04-12T09:15:12.667227Z"
+    },
+    {
+      "phase": "final-commit",
+      "tokens": 0,
+      "duration_ms": 0,
+      "model": "",
+      "timestamp": "2026-04-12T09:15:12.669628Z"
+    }
+  ],
+  "timestamps": {
+    "created": "2026-04-12T08:10:32.152285Z",
+    "lastUpdated": "2026-04-12T09:15:12.67023Z",
+    "phaseStarted": null
+  },
+  "error": null
+}

--- a/.specs/20260412-add-pipeline-e2e-integration-test/summary.md
+++ b/.specs/20260412-add-pipeline-e2e-integration-test/summary.md
@@ -1,0 +1,38 @@
+## Summary
+
+Added `mcp-server/internal/tools/pipeline_e2e_test.go` (269 lines) — four end-to-end integration tests that drive the full pipeline from `setup` to `completed` using mock artifact writes in place of a real LLM agent. The tests exercise `PipelineNextActionHandler` and `PipelineReportResultHandler` in a loop, covering cross-phase ordering regressions that were not previously caught by unit or integration tests. Three test variants (standard, light, full templates) are handled as table-driven subtests in `TestE2E_Templates`, and a fourth standalone test `TestE2E_DesignRevisionCycle` exercises the REVISE-then-APPROVE path with assertion on `DesignRevisions == 1`. All 13 Go packages pass under `go test -race ./...`.
+
+PR: https://github.com/hiromaily/claude-forge/pull/151
+
+## Pipeline Statistics
+- Total tokens: 310,636
+- Total duration: 844,570 ms
+- Estimated cost: $1.86
+- Phases executed: 10
+- Phases skipped: 2
+- Retries: 0
+- Review findings: 0 critical, 3 minor
+
+## Improvement Report
+
+_Retrospective on what would have made this work easier._
+
+### Documentation
+
+The task decomposer specified running `golangci-lint` against a single `_test.go` file path rather than a package path (`./internal/tools/...`). Running the linter on a single test file produces typecheck errors because sibling test-file helpers are not visible. The task description should always specify package-scope lint invocations. A note in `.claude/rules/` clarifying this convention would prevent future confusion.
+
+The investigation phase had to re-read `pipeline_report_result.go` multiple times to determine whether `phase5CompletionGate` blocked on missing `impl-N.md` files or on `ImplStatus` state. A short inline comment near the `phase5CompletionGate` call explaining that task status is updated by `determineTransition` (not by the mock) would shorten investigation.
+
+### Code Readability
+
+`handlePhaseThreeB` silently bypasses checkpoint-a when `AutoApprove=true` and APPROVE verdict is present — dispatching phase-4 directly without emitting a checkpoint action. This is not obvious from the function name. A comment at the dispatch point would prevent future agents from re-verifying this.
+
+`BranchClassified` is not part of `PipelineConfig`, requiring a separate `sm.Update` call after `sm.Configure`. Either including it in `PipelineConfig` or adding a comment near the struct noting the separate-update requirement would reduce friction.
+
+### AI Agent Support (Skills / Rules)
+
+The pipeline engine has a bug where, after phase-3b returns REVISE, `pipeline_next_action` (with `previous_action_complete=false`) dispatches the architect (phase-3) correctly, but `pipeline_next_action` (with `previous_action_complete=true`) after the architect revision reads the old `review-design.md` (still REVISE) and returns `revision_required` instead of dispatching the design-reviewer. This creates an infinite loop that required manual workaround (manually spawning the design-reviewer). This should be tracked as a bug fix in BACKLOG.md.
+
+### Other
+
+The comprehensive-review mid-run statistics differed from the end-of-run analytics figures because the analytics tool accumulates data incrementally. The convention to use `analytics_pipeline_summary` as the authoritative source is correctly documented and worked as expected.

--- a/mcp-server/internal/tools/pipeline_e2e_test.go
+++ b/mcp-server/internal/tools/pipeline_e2e_test.go
@@ -1,0 +1,269 @@
+// Package tools — end-to-end integration tests for the full pipeline flow.
+// These tests drive PipelineNextActionHandler → mock artifact writes →
+// PipelineReportResultHandler through every phase until ActionDone, using
+// a real state.json in a temp directory and no external services.
+package tools
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/hiromaily/claude-forge/mcp-server/internal/history"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/orchestrator"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/state"
+)
+
+// e2eConfig holds per-test pipeline configuration for E2E tests.
+type e2eConfig struct {
+	effort              string // state.EffortM, state.EffortS, state.EffortL
+	template            string // state.TemplateStandard, TemplateLight, TemplateFull
+	reviewDesignVerdict string // verdict written to review-design.md on first phase-3b spawn; defaults to "APPROVE" if empty
+}
+
+// setupE2EWorkspace initialises a workspace with the given config and returns
+// handler closures for pipeline_next_action and pipeline_report_result.
+func setupE2EWorkspace(
+	t *testing.T,
+	cfg e2eConfig,
+) (workspace string, nextActionH server.ToolHandlerFunc, reportResultH server.ToolHandlerFunc) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	sm := state.NewStateManager("dev")
+	if err := sm.Init(dir, "e2e-test"); err != nil {
+		t.Fatalf("sm.Init: %v", err)
+	}
+	if err := sm.Configure(dir, state.PipelineConfig{
+		Effort:        cfg.effort,
+		FlowTemplate:  cfg.template,
+		AutoApprove:   true,
+		SkipPR:        true,
+		SkippedPhases: orchestrator.SkipsForTemplate(cfg.template),
+	}); err != nil {
+		t.Fatalf("sm.Configure: %v", err)
+	}
+	if err := sm.Update(func(s *state.State) error {
+		s.BranchClassified = true
+		return nil
+	}); err != nil {
+		t.Fatalf("sm.Update (BranchClassified): %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, state.ArtifactRequest),
+		[]byte("# Request\n\ntest task\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write request.md: %v", err)
+	}
+
+	eng := orchestrator.NewEngine("", "")
+	kb := history.NewKnowledgeBase("")
+	nextActionH = PipelineNextActionHandler(sm, eng, "", nil, kb, nil)
+	reportResultH = PipelineReportResultHandler(state.NewStateManager("dev"), kb)
+
+	return dir, nextActionH, reportResultH
+}
+
+// mockAgentExecute writes the minimum artifact content satisfying artifact validation
+// for the given action phase. When approveOverride is non-nil and true, phase-3b
+// always writes an APPROVE verdict regardless of cfg.reviewDesignVerdict.
+func mockAgentExecute(
+	t *testing.T,
+	workspace string,
+	action orchestrator.Action,
+	cfg e2eConfig,
+	approveOverride *bool,
+) {
+	t.Helper()
+
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(workspace, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("mockAgentExecute write %s: %v", name, err)
+		}
+	}
+
+	switch action.Phase {
+	case state.PhaseOne:
+		write(state.ArtifactAnalysis, "# Analysis\n\nSituation analysis.\n")
+	case state.PhaseTwo:
+		write(state.ArtifactInvestigation, "# Investigation\n\nFindings.\n")
+	case state.PhaseThree:
+		write(state.ArtifactDesign, "# Design\n\n## Approach\n\nDetails.\n")
+		// Remove the previous review-design.md so handlePhaseThreeB dispatches
+		// the design reviewer (not the architect again) on the next phase-3b call.
+		_ = os.Remove(filepath.Join(workspace, state.ArtifactReviewDesign))
+	case state.PhaseThreeB:
+		switch {
+		case approveOverride != nil && *approveOverride:
+			write(state.ArtifactReviewDesign, "# Review\n\n## Verdict: APPROVE\n")
+		case cfg.reviewDesignVerdict == "" || cfg.reviewDesignVerdict == "APPROVE":
+			write(state.ArtifactReviewDesign, "# Review\n\n## Verdict: APPROVE\n")
+		default:
+			write(state.ArtifactReviewDesign,
+				"# Review\n\n## Verdict: REVISE\n\n### Findings\n\n**1. [CRITICAL] Design flaw.**\n")
+		}
+	case state.PhaseFour:
+		write(state.ArtifactTasks, "# Tasks\n\n## Task 1: Implement\n\nApply design.\n\nmode: sequential\n")
+	case state.PhaseFourB:
+		write(state.ArtifactReviewTasks, "# Review\n\n## Verdict: APPROVE\n")
+	case state.PhaseFive:
+		write("impl-1.md", "# Implementation\n\nDone.\n")
+	case state.PhaseSix:
+		write("review-1.md", "# Review\n\nPASS\n")
+	case state.PhaseSeven:
+		write(state.ArtifactComprehensiveReview, "# Comprehensive Review\n\nAll good.\n")
+	case state.PhaseFinalVerification:
+		write(state.ArtifactFinalVerification, "# Final Verification\n\nPassed.\n")
+	case state.PhaseFinalSummary:
+		write(state.ArtifactSummary, "# Summary\n\nCompleted.\n")
+	default:
+		t.Logf("mockAgentExecute: no artifact rule for phase %q; skipping", action.Phase)
+	}
+}
+
+// runE2EPipeline drives the full pipeline loop until ActionDone or 60 iterations.
+// Returns true if a revision cycle was detected (phase-3b returned revision_required).
+func runE2EPipeline(
+	t *testing.T,
+	cfg e2eConfig,
+	workspace string,
+	nextActionH server.ToolHandlerFunc,
+	reportResultH server.ToolHandlerFunc,
+) (revisionCycleDetected bool) {
+	t.Helper()
+
+	approveOverride := new(bool) // *bool pointing to false
+	revisionCycleDetected = false
+
+	for range 60 {
+		result, err := callNextAction(t, nextActionH, workspace)
+		if err != nil {
+			t.Fatalf("runE2EPipeline: callNextAction returned Go error: %v", err)
+		}
+		if result.IsError {
+			t.Fatalf("runE2EPipeline: callNextAction returned MCP error: %s", textContent(result))
+		}
+
+		var resp nextActionResponse
+		if err := json.Unmarshal([]byte(textContent(result)), &resp); err != nil {
+			t.Fatalf("runE2EPipeline: unmarshal nextActionResponse: %v (raw: %s)", err, textContent(result))
+		}
+
+		if resp.Action.Type == orchestrator.ActionDone {
+			return revisionCycleDetected
+		}
+
+		// Determine the phase to report. For checkpoint actions, the phase is
+		// stored in Action.Name (e.g. "checkpoint-a"), not Action.Phase (which is empty).
+		reportPhase := resp.Action.Phase
+		if resp.Action.Type == orchestrator.ActionCheckpoint && reportPhase == "" {
+			reportPhase = resp.Action.Name
+		}
+
+		switch resp.Action.Type {
+		case orchestrator.ActionWriteFile:
+			if err := os.WriteFile(resp.Action.Path, []byte(resp.Action.Content), 0o600); err != nil {
+				t.Fatalf("runE2EPipeline: write_file %s: %v", resp.Action.Path, err)
+			}
+		case orchestrator.ActionSpawnAgent:
+			mockAgentExecute(t, workspace, resp.Action, cfg, approveOverride)
+		case orchestrator.ActionCheckpoint:
+			// no artifact write needed; reportResult call below advances state
+		case orchestrator.ActionExec:
+			// no mock artifact write needed; reportResult call below records phase-log
+		default:
+			t.Logf("runE2EPipeline: unhandled action type %q for phase %q", resp.Action.Type, resp.Action.Phase)
+		}
+
+		// Single post-switch reportResult call for ALL action types.
+		reportRes := callTool(t, reportResultH, map[string]any{
+			"workspace":   workspace,
+			"phase":       reportPhase,
+			"tokens_used": 500,
+			"duration_ms": 1000,
+			"model":       "sonnet",
+		})
+		if reportRes.IsError {
+			t.Fatalf("runE2EPipeline: callReportResult for phase %q returned MCP error: %s",
+				resp.Action.Phase, textContent(reportRes))
+		}
+
+		// Detect revision_required for phase-3b and set approveOverride for next phase-3b call.
+		if resp.Action.Phase == state.PhaseThreeB && !*approveOverride {
+			rro := parsePRRResponse(t, textContent(reportRes))
+			if rro.NextActionHint == "revision_required" {
+				revisionCycleDetected = true
+				*approveOverride = true
+			}
+		}
+	}
+
+	t.Fatalf("runE2EPipeline: pipeline did not reach ActionDone within 60 iterations")
+	return false // unreachable; satisfies compiler
+}
+
+// TestE2E_Templates is a table-driven test covering three template variants.
+// Each subtest drives the full pipeline to completion and asserts currentPhase == completed.
+func TestE2E_Templates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		effort   string
+	}{
+		{name: "standard_template", template: state.TemplateStandard, effort: state.EffortM},
+		{name: "light_template", template: state.TemplateLight, effort: state.EffortS},
+		{name: "full_template", template: state.TemplateFull, effort: state.EffortL},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := e2eConfig{effort: tc.effort, template: tc.template}
+			workspace, nextActionH, reportResultH := setupE2EWorkspace(t, cfg)
+			runE2EPipeline(t, cfg, workspace, nextActionH, reportResultH)
+
+			s, err := state.ReadState(workspace)
+			if err != nil {
+				t.Fatalf("ReadState: %v", err)
+			}
+			if s.CurrentPhase != state.PhaseCompleted {
+				t.Errorf("currentPhase = %q, want %q", s.CurrentPhase, state.PhaseCompleted)
+			}
+		})
+	}
+}
+
+// TestE2E_DesignRevisionCycle verifies that a REVISE verdict on phase-3b triggers
+// a revision cycle, increments DesignRevisions to 1, and the pipeline still completes.
+func TestE2E_DesignRevisionCycle(t *testing.T) {
+	t.Parallel()
+	cfg := e2eConfig{
+		effort:              state.EffortM,
+		template:            state.TemplateStandard,
+		reviewDesignVerdict: "REVISE",
+	}
+	workspace, nextActionH, reportResultH := setupE2EWorkspace(t, cfg)
+	revisionDetected := runE2EPipeline(t, cfg, workspace, nextActionH, reportResultH)
+
+	if !revisionDetected {
+		t.Errorf("expected revision cycle to be detected, got revisionDetected=false")
+	}
+
+	s, err := state.ReadState(workspace)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if s.CurrentPhase != state.PhaseCompleted {
+		t.Errorf("currentPhase = %q, want %q", s.CurrentPhase, state.PhaseCompleted)
+	}
+	if s.Revisions.DesignRevisions != 1 {
+		t.Errorf("DesignRevisions = %d, want 1", s.Revisions.DesignRevisions)
+	}
+}

--- a/mcp-server/internal/tools/pipeline_e2e_test.go
+++ b/mcp-server/internal/tools/pipeline_e2e_test.go
@@ -64,7 +64,7 @@ func setupE2EWorkspace(
 	eng := orchestrator.NewEngine("", "")
 	kb := history.NewKnowledgeBase("")
 	nextActionH = PipelineNextActionHandler(sm, eng, "", nil, kb, nil)
-	reportResultH = PipelineReportResultHandler(state.NewStateManager("dev"), kb)
+	reportResultH = PipelineReportResultHandler(sm, kb)
 
 	return dir, nextActionH, reportResultH
 }
@@ -178,7 +178,7 @@ func runE2EPipeline(
 		case orchestrator.ActionExec:
 			// no mock artifact write needed; reportResult call below records phase-log
 		default:
-			t.Logf("runE2EPipeline: unhandled action type %q for phase %q", resp.Action.Type, resp.Action.Phase)
+			t.Fatalf("runE2EPipeline: unhandled action type %q for phase %q", resp.Action.Type, resp.Action.Phase)
 		}
 
 		// Single post-switch reportResult call for ALL action types.


### PR DESCRIPTION
## Summary

Added `mcp-server/internal/tools/pipeline_e2e_test.go` (269 lines) — four end-to-end integration tests that drive the full pipeline from `setup` to `completed` using mock artifact writes in place of a real LLM agent. The tests exercise `PipelineNextActionHandler` and `PipelineReportResultHandler` in a loop, covering cross-phase ordering regressions that were not previously caught by unit or integration tests. Three test variants (standard, light, full templates) are handled as table-driven subtests in `TestE2E_Templates`, and a fourth standalone test `TestE2E_DesignRevisionCycle` exercises the REVISE-then-APPROVE path with assertion on `DesignRevisions == 1`. All 13 Go packages pass under `go test -race ./...`.

PR: https://github.com/hiromaily/claude-forge/pull/151

## Pipeline Statistics
- Total tokens: 310,636
- Total duration: 844,570 ms
- Estimated cost: $1.86
- Phases executed: 10
- Phases skipped: 2
- Retries: 0
- Review findings: 0 critical, 3 minor

## Improvement Report

_Retrospective on what would have made this work easier._

### Documentation

The task decomposer specified running `golangci-lint` against a single `_test.go` file path rather than a package path (`./internal/tools/...`). Running the linter on a single test file produces typecheck errors because sibling test-file helpers are not visible. The task description should always specify package-scope lint invocations. A note in `.claude/rules/` clarifying this convention would prevent future confusion.

The investigation phase had to re-read `pipeline_report_result.go` multiple times to determine whether `phase5CompletionGate` blocked on missing `impl-N.md` files or on `ImplStatus` state. A short inline comment near the `phase5CompletionGate` call explaining that task status is updated by `determineTransition` (not by the mock) would shorten investigation.

### Code Readability

`handlePhaseThreeB` silently bypasses checkpoint-a when `AutoApprove=true` and APPROVE verdict is present — dispatching phase-4 directly without emitting a checkpoint action. This is not obvious from the function name. A comment at the dispatch point would prevent future agents from re-verifying this.

`BranchClassified` is not part of `PipelineConfig`, requiring a separate `sm.Update` call after `sm.Configure`. Either including it in `PipelineConfig` or adding a comment near the struct noting the separate-update requirement would reduce friction.

### AI Agent Support (Skills / Rules)

The pipeline engine has a bug where, after phase-3b returns REVISE, `pipeline_next_action` (with `previous_action_complete=false`) dispatches the architect (phase-3) correctly, but `pipeline_next_action` (with `previous_action_complete=true`) after the architect revision reads the old `review-design.md` (still REVISE) and returns `revision_required` instead of dispatching the design-reviewer. This creates an infinite loop that required manual workaround (manually spawning the design-reviewer). This should be tracked as a bug fix in BACKLOG.md.

### Other

The comprehensive-review mid-run statistics differed from the end-of-run analytics figures because the analytics tool accumulates data incrementally. The convention to use `analytics_pipeline_summary` as the authoritative source is correctly documented and worked as expected.
