### PR TITLE
feat(orchestrator): add Closes #N to PR body for GitHub issue pipelines

### DIFF
--- a/mcp-server/internal/orchestrator/engine.go
+++ b/mcp-server/internal/orchestrator/engine.go
@@ -867,6 +867,21 @@ func readSourceID(workspace string) string {
 	return readFrontMatterField(workspace, "source_id", "")
 }
 
+// ClosingRef returns the GitHub issue closing reference for the given workspace,
+// e.g. "\n\nCloses #42", or "" if the pipeline was not started from a GitHub issue
+// or if no source_id is present.  Used by executeFinalCommit to persist the
+// closing reference in the final PR body after summary.md replaces the placeholder.
+func ClosingRef(workspace string) string {
+	if readSourceType(workspace) != state.SourceTypeGitHub {
+		return ""
+	}
+	issueNum := readSourceID(workspace)
+	if issueNum == "" {
+		return ""
+	}
+	return "\n\nCloses #" + issueNum
+}
+
 // DeriveBranchName generates a deterministic branch name from the spec name.
 // It strips the date prefix (e.g., "20260330-") and truncates to 60 characters
 // to produce readable branch names like "feature/soa-2899-task-status-options".

--- a/mcp-server/internal/orchestrator/engine.go
+++ b/mcp-server/internal/orchestrator/engine.go
@@ -58,6 +58,7 @@ type Engine struct {
 	verdictReader    func(path string) (Verdict, []Finding, error)
 	sourceTypeReader func(workspace string) string
 	sourceURLReader  func(workspace string) string
+	sourceIDReader   func(workspace string) string
 }
 
 // NewEngine constructs a ready-to-use Engine with production I/O implementations.
@@ -69,6 +70,7 @@ func NewEngine(agentDir, specsDir string) *Engine {
 		verdictReader:    ParseVerdict,
 		sourceTypeReader: readSourceType,
 		sourceURLReader:  readSourceURL,
+		sourceIDReader:   readSourceID,
 	}
 }
 
@@ -685,7 +687,7 @@ func (*Engine) handleFinalVerification(_ *state.State) (Action, error) {
 //	the PR number. A placeholder body is used here; executeFinalCommit updates
 //	the PR body with the full summary.md via `gh pr edit` after final-summary
 //	completes. See executeFinalCommit in git_ops.go for the body-update step.
-func (*Engine) handlePRCreation(st *state.State) (Action, error) {
+func (e *Engine) handlePRCreation(st *state.State) (Action, error) {
 	// Decision 24 — PR skip (runtime SkipPr flag)
 	// Note: Decision 14 already handles the case where pr-creation is in SkippedPhases.
 	if st.SkipPr {
@@ -695,6 +697,12 @@ func (*Engine) handlePRCreation(st *state.State) (Action, error) {
 	title := derivePRTitle(st)
 
 	body := "[forge] Pipeline summary will be generated shortly.\n\nSpec: " + st.SpecName
+
+	if e.sourceTypeReader(st.Workspace) == state.SourceTypeGitHub {
+		if issueNum := e.sourceIDReader(st.Workspace); issueNum != "" {
+			body += "\n\nCloses #" + issueNum
+		}
+	}
 
 	return NewExecAction(PhasePRCreation, []string{
 		"gh", "pr", "create",
@@ -851,6 +859,12 @@ func readSourceType(workspace string) string {
 // Returns "" when the field is absent or the file is unreadable.
 func readSourceURL(workspace string) string {
 	return readFrontMatterField(workspace, "source_url", "")
+}
+
+// readSourceID reads the source_id field from {workspace}/request.md front matter.
+// Returns "" when the field is absent or the file is unreadable.
+func readSourceID(workspace string) string {
+	return readFrontMatterField(workspace, "source_id", "")
 }
 
 // DeriveBranchName generates a deterministic branch name from the spec name.

--- a/mcp-server/internal/orchestrator/engine_test.go
+++ b/mcp-server/internal/orchestrator/engine_test.go
@@ -155,6 +155,78 @@ func TestReadSourceType(t *testing.T) {
 	}
 }
 
+// TestClosingRef groups tests for the ClosingRef exported helper.
+func TestClosingRef(t *testing.T) {
+	t.Parallel()
+
+	writeRequest := func(t *testing.T, content string) string {
+		t.Helper()
+		dir := t.TempDir()
+		if err := writeFileForTest(dir+"/request.md", content); err != nil {
+			t.Fatalf("writeFileForTest: %v", err)
+		}
+		return dir
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+		want  string
+	}{
+		{
+			name: "github_with_id",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return writeRequest(t, "---\nsource_type: github_issue\nsource_id: 42\n---\n")
+			},
+			want: "\n\nCloses #42",
+		},
+		{
+			name: "github_no_id",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return writeRequest(t, "---\nsource_type: github_issue\n---\n")
+			},
+			want: "",
+		},
+		{
+			name: "text_source",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return writeRequest(t, "---\nsource_type: text\nsource_id: 99\n---\n")
+			},
+			want: "",
+		},
+		{
+			name: "jira_source",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return writeRequest(t, "---\nsource_type: jira_issue\nsource_id: 10\n---\n")
+			},
+			want: "",
+		},
+		{
+			name: "missing_request_md",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := tc.setup(t)
+			got := ClosingRef(dir)
+			if got != tc.want {
+				t.Errorf("ClosingRef(%q) = %q, want %q", dir, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestSortedTaskKeys groups tests for the sortedTaskKeys helper.
 func TestSortedTaskKeys(t *testing.T) {
 	t.Parallel()

--- a/mcp-server/internal/orchestrator/engine_test.go
+++ b/mcp-server/internal/orchestrator/engine_test.go
@@ -214,14 +214,16 @@ type nextActionTestCase struct {
 	// eng overrides; if nil, a default stub engine (approve + text) is used.
 	engFn func() *Engine
 	// assertions on the returned action
-	wantErr           bool // true: expect non-nil error from NextAction
-	wantType          string
-	wantAgent         string
-	wantSummary       string
-	wantPhase         string   // non-empty: assert action.Phase equals this value
-	wantParallelIDs   []string // nil means "do not check"; empty slice means "assert len==0"
-	wantInputContains string   // non-empty: assert InputFiles contains this value
-	wantSetupOnly     *bool    // non-nil: assert action.SetupOnly equals *wantSetupOnly
+	wantErr                bool // true: expect non-nil error from NextAction
+	wantType               string
+	wantAgent              string
+	wantSummary            string
+	wantPhase              string   // non-empty: assert action.Phase equals this value
+	wantParallelIDs        []string // nil means "do not check"; empty slice means "assert len==0"
+	wantInputContains      string   // non-empty: assert InputFiles contains this value
+	wantSetupOnly          *bool    // non-nil: assert action.SetupOnly equals *wantSetupOnly
+	wantCommandContains    string   // non-empty: assert any Commands element contains this value
+	wantCommandNotContains string   // non-empty: assert no Commands element contains this value
 }
 
 // defaultEng returns an Engine with stubbed readers (approve + text).
@@ -894,6 +896,48 @@ func TestNextAction(t *testing.T) {
 			wantSummary: SkipSummaryPrefix + "pr-creation",
 		},
 
+		// ── Decision 24: github_issue source adds Closes #N to PR body ───────
+		{
+			name: "pr_creation_github_issue_closes",
+			setupSM: func(t *testing.T) *state.StateManager {
+				t.Helper()
+				return newTestStateManager(t, "pr-creation", nil)
+			},
+			engFn: func() *Engine {
+				return &Engine{
+					agentDir:         "/test/agents",
+					specsDir:         "/test/specs",
+					verdictReader:    stubVerdictReader(VerdictApprove),
+					sourceTypeReader: stubSourceTypeReader(state.SourceTypeGitHub),
+					sourceIDReader:   func(_ string) string { return "42" },
+				}
+			},
+			wantType:            ActionExec,
+			wantPhase:           PhasePRCreation,
+			wantCommandContains: "Closes #42",
+		},
+
+		// ── Decision 24: non-github source does NOT add Closes to PR body ────
+		{
+			name: "pr_creation_text_source_no_closes",
+			setupSM: func(t *testing.T) *state.StateManager {
+				t.Helper()
+				return newTestStateManager(t, "pr-creation", nil)
+			},
+			engFn: func() *Engine {
+				return &Engine{
+					agentDir:         "/test/agents",
+					specsDir:         "/test/specs",
+					verdictReader:    stubVerdictReader(VerdictApprove),
+					sourceTypeReader: stubSourceTypeReader("text"),
+					sourceIDReader:   func(_ string) string { return "42" },
+				}
+			},
+			wantType:               ActionExec,
+			wantPhase:              PhasePRCreation,
+			wantCommandNotContains: "Closes #",
+		},
+
 		// ── Decision 25: final-summary uses fixed input file list ───────────
 		{
 			name: "final_summary_fixed_inputs",
@@ -1075,6 +1119,28 @@ func TestNextAction(t *testing.T) {
 			if tc.wantSetupOnly != nil {
 				if action.SetupOnly != *tc.wantSetupOnly {
 					t.Errorf("action.SetupOnly = %v, want %v", action.SetupOnly, *tc.wantSetupOnly)
+				}
+			}
+
+			if tc.wantCommandContains != "" {
+				found := false
+				for _, cmd := range action.Commands {
+					if strings.Contains(cmd, tc.wantCommandContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Commands = %v; expected one element to contain %q", action.Commands, tc.wantCommandContains)
+				}
+			}
+
+			if tc.wantCommandNotContains != "" {
+				for _, cmd := range action.Commands {
+					if strings.Contains(cmd, tc.wantCommandNotContains) {
+						t.Errorf("Commands = %v; expected no element to contain %q", action.Commands, tc.wantCommandNotContains)
+						break
+					}
 				}
 			}
 		})

--- a/mcp-server/internal/tools/git_ops.go
+++ b/mcp-server/internal/tools/git_ops.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/history"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/orchestrator"
 	"github.com/hiromaily/claude-forge/mcp-server/internal/state"
 )
 
@@ -193,14 +194,29 @@ func executeFinalCommit(workspace string, sm *state.StateManager, kb *history.Kn
 	// later in the final-summary phase. Now that summary.md exists, replace the
 	// PR body with the complete version. `gh pr edit` targets the PR on the
 	// current branch — no explicit PR number needed.
+	// If this is a GitHub issue pipeline, append "Closes #N" so that the reference
+	// persists in the final PR body (the initial placeholder body added it, but
+	// --body-file would overwrite it without this step).
 	// Best-effort: if `gh` is not available or the edit fails (e.g. CI, test env),
 	// log a warning and continue — the PR body will retain the placeholder but
 	// the commit and push must still succeed.
 	summaryPath := filepath.Join(workspace, "summary.md")
 	if _, statErr := os.Stat(summaryPath); statErr != nil {
 		fmt.Fprintf(os.Stderr, "warning: executeFinalCommit: summary.md not found, skipping PR body update\n")
-	} else if err := runCommand(repo, "gh", "pr", "edit", "--body-file", summaryPath); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: executeFinalCommit: gh pr edit failed (non-fatal): %v\n", err)
+	} else {
+		bodyFile, closingRefErr := prBodyFileWithClosingRef(summaryPath, orchestrator.ClosingRef(workspace))
+		if closingRefErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: executeFinalCommit: failed to build PR body: %v\n", closingRefErr)
+		} else {
+			defer func() {
+				if bodyFile != summaryPath {
+					_ = os.Remove(bodyFile)
+				}
+			}()
+			if err := runCommand(repo, "gh", "pr", "edit", "--body-file", bodyFile); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: executeFinalCommit: gh pr edit failed (non-fatal): %v\n", err)
+			}
+		}
 	}
 
 	// Step 4: Force-add workspace artifacts (state.json and summary.md if it exists).
@@ -240,6 +256,36 @@ func executeFinalCommit(workspace string, sm *state.StateManager, kb *history.Kn
 	}
 
 	return nil
+}
+
+// prBodyFileWithClosingRef returns the path to a file suitable for `gh pr edit --body-file`.
+// When closingRef is empty the original summaryPath is returned unchanged.
+// When closingRef is non-empty the summary content is combined with the closing
+// reference into a temp file and that temp file path is returned; the caller is
+// responsible for deleting it.
+func prBodyFileWithClosingRef(summaryPath, closingRef string) (string, error) {
+	if closingRef == "" {
+		return summaryPath, nil
+	}
+	content, err := os.ReadFile(summaryPath)
+	if err != nil {
+		return "", fmt.Errorf("prBodyFileWithClosingRef read: %w", err)
+	}
+	combined := append(content, []byte(closingRef)...)
+	tmp, err := os.CreateTemp("", "forge-pr-body-*.md")
+	if err != nil {
+		return "", fmt.Errorf("prBodyFileWithClosingRef tempfile: %w", err)
+	}
+	if _, err := tmp.Write(combined); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return "", fmt.Errorf("prBodyFileWithClosingRef write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return "", fmt.Errorf("prBodyFileWithClosingRef close: %w", err)
+	}
+	return tmp.Name(), nil
 }
 
 // runCommand executes a non-git command with the given working directory.

--- a/mcp-server/internal/tools/git_ops.go
+++ b/mcp-server/internal/tools/git_ops.go
@@ -271,12 +271,12 @@ func prBodyFileWithClosingRef(summaryPath, closingRef string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("prBodyFileWithClosingRef read: %w", err)
 	}
-	combined := append(content, []byte(closingRef)...)
+	content = append(content, []byte(closingRef)...)
 	tmp, err := os.CreateTemp("", "forge-pr-body-*.md")
 	if err != nil {
 		return "", fmt.Errorf("prBodyFileWithClosingRef tempfile: %w", err)
 	}
-	if _, err := tmp.Write(combined); err != nil {
+	if _, err := tmp.Write(content); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmp.Name())
 		return "", fmt.Errorf("prBodyFileWithClosingRef write: %w", err)

--- a/mcp-server/internal/tools/git_ops_test.go
+++ b/mcp-server/internal/tools/git_ops_test.go
@@ -12,6 +12,70 @@ import (
 	"github.com/hiromaily/claude-forge/mcp-server/internal/state"
 )
 
+// TestPRBodyFileWithClosingRef verifies that prBodyFileWithClosingRef returns
+// the original path when closingRef is empty, and creates a combined temp file
+// with the closing reference appended when closingRef is non-empty.
+func TestPRBodyFileWithClosingRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		summaryContent string
+		closingRef     string
+		wantSamePath   bool   // true = returned path must equal summaryPath
+		wantContains   string // substring that must appear in file content
+	}{
+		{
+			name:           "no_closing_ref",
+			summaryContent: "# Summary\n\nSome content.\n",
+			closingRef:     "",
+			wantSamePath:   true,
+			wantContains:   "# Summary",
+		},
+		{
+			name:           "with_closing_ref",
+			summaryContent: "# Summary\n\nSome content.\n",
+			closingRef:     "\n\nCloses #42",
+			wantSamePath:   false,
+			wantContains:   "Closes #42",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			summaryPath := filepath.Join(dir, "summary.md")
+			if err := os.WriteFile(summaryPath, []byte(tc.summaryContent), 0o600); err != nil {
+				t.Fatalf("write summary.md: %v", err)
+			}
+
+			got, err := prBodyFileWithClosingRef(summaryPath, tc.closingRef)
+			if err != nil {
+				t.Fatalf("prBodyFileWithClosingRef: %v", err)
+			}
+			if got != summaryPath {
+				defer func() { _ = os.Remove(got) }()
+			}
+
+			if tc.wantSamePath && got != summaryPath {
+				t.Errorf("expected same path %q, got %q", summaryPath, got)
+			}
+			if !tc.wantSamePath && got == summaryPath {
+				t.Errorf("expected temp file path, got original summary path %q", got)
+			}
+
+			content, err := os.ReadFile(got)
+			if err != nil {
+				t.Fatalf("ReadFile(%q): %v", got, err)
+			}
+			if !strings.Contains(string(content), tc.wantContains) {
+				t.Errorf("file content %q does not contain %q", string(content), tc.wantContains)
+			}
+		})
+	}
+}
+
 // initGitRepo initialises a bare git repository in dir so that repoRoot and
 // git commands work correctly.  A dummy initial commit is created so that
 // `git diff --name-only HEAD` does not fail with "no commits yet".


### PR DESCRIPTION
## Summary

- When `/forge` is invoked with a GitHub issue URL, the generated PR now includes `Closes #<N>` in its body, so GitHub auto-closes the source issue on merge
- Added `sourceIDReader` injectable field to `Engine` (parallel to existing `sourceTypeReader`/`sourceURLReader`) and a `readSourceID` helper that reads `source_id` from `request.md` front matter
- Added `wantCommandContains` / `wantCommandNotContains` assertion fields to the `nextActionTestCase` struct; added two new test cases covering presence and absence of the closing reference

## Test plan

- [ ] `cd mcp-server && go test -race ./internal/orchestrator/...` — all passing
- [ ] New case `pr_creation_github_issue_closes` asserts `Closes #42` appears in the `gh pr create --body` argument
- [ ] New case `pr_creation_text_source_no_closes` asserts `Closes #` does NOT appear when source type is plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)