### PR TITLE
fix(agents): display total duration as human-readable string in summary

### DIFF
--- a/agents/comprehensive-reviewer.md
+++ b/agents/comprehensive-reviewer.md
@@ -69,7 +69,7 @@ mcp__forge-state__analytics_pipeline_summary(workspace: "{workspace}")
 Include the following fields from the response in the summary document under a `## Pipeline Statistics` section:
 
 - `total_tokens` — total tokens consumed across all phases
-- `total_duration_ms` — total wall-clock duration in milliseconds
+- `total_duration` — total wall-clock duration as a human-readable string (e.g., "14m 4s")
 - `estimated_cost_usd` — estimated cost in USD
 - `phases_executed` — number of phases that were executed
 - `phases_skipped` — number of phases that were skipped
@@ -98,7 +98,7 @@ Return a markdown report with this structure:
 
 ## Pipeline Statistics
 - Total tokens: {total_tokens}
-- Total duration: {total_duration_ms} ms
+- Total duration: {total_duration}
 - Estimated cost: ${estimated_cost_usd}
 - Phases executed: {phases_executed}
 - Phases skipped: {phases_skipped}

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -48,7 +48,7 @@ mcp__forge-state__analytics_pipeline_summary(workspace: "{workspace}")
 Include the following fields from the response in the summary document under a `## Pipeline Statistics` section:
 
 - `total_tokens` — total tokens consumed across all phases
-- `total_duration_ms` — total wall-clock duration in milliseconds
+- `total_duration` — total wall-clock duration as a human-readable string (e.g., "14m 4s")
 - `estimated_cost_usd` — estimated cost in USD
 - `phases_executed` — number of phases that were executed
 - `phases_skipped` — number of phases that were skipped
@@ -112,7 +112,7 @@ Skip this section entirely when the input artifacts do not include `analysis.md`
 
 ## Pipeline Statistics
 - Total tokens: {total_tokens}
-- Total duration: {total_duration_ms} ms
+- Total duration: {total_duration}
 - Estimated cost: ${estimated_cost_usd}
 - Phases executed: {phases_executed}
 - Phases skipped: {phases_skipped}


### PR DESCRIPTION
## Summary

- Replace `{total_duration_ms} ms` with `{total_duration}` in the Pipeline Statistics template for `verifier.md` and `comprehensive-reviewer.md`
- Update field description to reference `total_duration` (the pre-formatted string) instead of `total_duration_ms`
- The `analytics_pipeline_summary` MCP tool already returns a `total_duration` field (e.g. "14m 4s"); agents were incorrectly using the raw millisecond value

## Test plan

- [ ] Run a pipeline and verify `summary.md` shows `Total duration: 14m 4s` style output instead of `Total duration: 844570 ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)