### PR TITLE
Feature/source id in branch and pr title

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,441 @@ The `forge-state` server exposes **44 typed MCP tools** across six categories:
 
 ---
 
+# MCP Data Contracts
+
+This document specifies the exact JSON payloads exchanged between the Claude orchestrator (SKILL.md) and the Go MCP server (`forge-state-mcp`) during a pipeline run. These four tools drive the entire pipeline lifecycle.
+
+> **Source of truth**: The Go structs in `mcp-server/internal/tools/` and `mcp-server/internal/orchestrator/actions.go`. This document mirrors those definitions — update both when changing schemas.
+
+---
+
+## 1. `pipeline_init` — Input Parsing & Resume Detection
+
+Pure detection tool. Parses the raw `/forge` arguments, detects source type, checks for resume candidates. **No side effects on state.**
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `arguments` | string | yes | Raw arguments string passed to `/forge` |
+| `current_branch` | string | no | Output of `git branch --show-current` |
+
+### Response
+
+**Resume path** (input matches existing `.specs/` directory):
+
+```json
+{
+  "resume_mode": "auto",
+  "workspace": ".specs/20260330-fix-auth-timeout",
+  "instruction": "call state_resume_info"
+}
+```
+
+**New pipeline path**:
+
+```json
+{
+  "workspace": ".specs/20260401-https-github-com-owner-repo-issues-42",
+  "spec_name": "https-github-com-owner-repo-issues-42",
+  "source_type": "github_issue",
+  "source_url": "https://github.com/owner/repo/issues/42",
+  "source_id": "42",
+  "core_text": "https://github.com/owner/repo/issues/42",
+  "flags": {
+    "auto": false,
+    "skip_pr": false,
+    "debug": false,
+    "discuss": false,
+    "effort_override": null,
+    "current_branch": "main"
+  },
+  "fetch_needed": {
+    "type": "github",
+    "fields": ["labels", "title", "body"],
+    "instruction": "fetch github issue fields before calling pipeline_init_with_context"
+  }
+}
+```
+
+**Error path** (invalid input):
+
+```json
+{
+  "errors": ["input too short: minimum 3 characters required"]
+}
+```
+
+### `source_type` Values
+
+| Value | Trigger |
+|-------|---------|
+| `github_issue` | URL matching `github.com/.../issues/\d+` |
+| `jira_issue` | URL matching `*.atlassian.net/browse/...` |
+| `text` | Plain text (default) |
+| `workspace` | Input contains `.specs/` |
+
+---
+
+## 2. `pipeline_init_with_context` — Three-Call Confirmation Flow
+
+Implements a multi-call handshake: detect effort → (optional: discuss) → confirm & initialise workspace.
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workspace` | string | yes | Workspace path from `pipeline_init` |
+| `source_id` | string | no | Source identifier (e.g., `"42"`, `"SOA-123"`) |
+| `source_url` | string | no | Original URL (GitHub/Jira) |
+| `external_context` | object | no | Fetched GitHub/Jira fields (see below) |
+| `flags` | object | no | Parsed flags from `pipeline_init` |
+| `task_text` | string | no | Original task text (text source only) |
+| `user_confirmation` | object | no | Confirmed effort + branch decision (second call) |
+| `discussion_answers` | string | no | User answers to discussion questions |
+
+**`external_context` object:**
+
+```json
+{
+  "github_labels": ["bug", "priority-high"],
+  "github_title": "Fix auth timeout in middleware",
+  "github_body": "requests timeout after 30s",
+  "jira_issue_type": "Bug",
+  "jira_story_points": 3,
+  "jira_summary": "Skip minutes job without integration",
+  "jira_description": "..."
+}
+```
+
+**`user_confirmation` object (confirmation call):**
+
+```json
+{
+  "effort": "M",
+  "workspace_slug": "fix-auth-timeout",
+  "use_current_branch": false,
+  "enriched_request_body": "..."
+}
+```
+
+### Response — First Call (effort detection)
+
+Returns `needs_user_confirmation` for the orchestrator to present to the user:
+
+```json
+{
+  "needs_user_confirmation": {
+    "detected_effort": "M",
+    "effort_options": {
+      "S": {
+        "skipped_phases": [
+          { "phase_id": "phase-2", "label": "Investigation" },
+          { "phase_id": "phase-3b", "label": "Design Review" }
+        ],
+        "recommended": false
+      },
+      "M": {
+        "skipped_phases": [
+          { "phase_id": "phase-4b", "label": "Tasks Review" },
+          { "phase_id": "checkpoint-b", "label": "Human Reviews Tasks" }
+        ],
+        "recommended": true
+      },
+      "L": {
+        "skipped_phases": [],
+        "recommended": false
+      }
+    },
+    "current_branch": "main",
+    "is_main_branch": true,
+    "enriched_request_body": "implement login feature",
+    "message": "Detected effort=\"M\". ..."
+  }
+}
+```
+
+### Response — First Call with `--discuss` (text source only)
+
+```json
+{
+  "needs_discussion": {
+    "questions": [
+      "What is the main goal of this change?",
+      "Are there any constraints or dependencies?",
+      "What is the expected scope of changes?"
+    ],
+    "message": "Please answer the following questions..."
+  }
+}
+```
+
+### Response — Confirmation Call (workspace finalised)
+
+```json
+{
+  "ready": true,
+  "workspace": ".specs/20260401-42-fix-auth-timeout",
+  "effort": "M",
+  "flow_template": "standard",
+  "skipped_phases": ["phase-4b", "checkpoint-b"],
+  "request_md_content": "---\nsource_type: github_issue\n...",
+  "branch": "feature/42-fix-auth-timeout",
+  "create_branch": true
+}
+```
+
+### Call Discriminator
+
+| `discussion_answers` | `user_confirmation` | Path |
+|---|---|---|
+| absent | absent | First call → detect effort |
+| present | absent | Discussion call → enrich body |
+| absent | present | Confirmation call → init workspace |
+| present | present | **Error** — ambiguous |
+
+---
+
+## 3. `pipeline_next_action` — Action Dispatch
+
+The core loop driver. Reads `state.json`, runs `Engine.NextAction()` deterministically, returns a typed action for the orchestrator to execute.
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workspace` | string | yes | Workspace path |
+| `previous_action_complete` | boolean | no | True after agent/exec/write_file completes |
+| `previous_tokens` | number | no | Token count from previous action |
+| `previous_duration_ms` | number | no | Duration in ms of previous action |
+| `previous_model` | string | no | Model used for previous action |
+| `previous_setup_only` | boolean | no | True if previous exec was setup-only |
+| `user_response` | string | no | User response for checkpoint actions |
+
+### Response Structure
+
+Every response wraps an `Action` with optional metadata:
+
+```json
+{
+  "type": "spawn_agent",
+  "warning": "",
+  "display_message": "Phase 1: Situation Analysis",
+  "report_result": null,
+  ...action-specific fields...
+}
+```
+
+When `report_result` is non-null, the engine has recorded a phase result internally (this happens for `pipeline_report_result` calls routed through `pipeline_next_action`):
+
+```json
+{
+  "report_result": {
+    "next_action_hint": "revision_required",
+    "verdict_parsed": "REVISE",
+    "findings": [
+      { "severity": "CRITICAL", "description": "Missing error handling for..." }
+    ],
+    "warning": "",
+    "display_message": ""
+  }
+}
+```
+
+### Action Types
+
+#### `spawn_agent` — Dispatch an LLM subagent
+
+```json
+{
+  "type": "spawn_agent",
+  "agent": "situation-analyst",
+  "prompt": "...4-layer assembled prompt...",
+  "model": "sonnet",
+  "phase": "phase-1",
+  "input_files": ["request.md"],
+  "output_file": "analysis.md",
+  "parallel_task_ids": null
+}
+```
+
+The `prompt` field contains the **4-layer assembled prompt** (see below). When `parallel_task_ids` is non-empty, the orchestrator spawns one agent per task ID concurrently.
+
+#### `checkpoint` — Pause for human review
+
+```json
+{
+  "type": "checkpoint",
+  "name": "checkpoint-a",
+  "present_to_user": "## Design Review\n\n...",
+  "options": ["approve", "reject"]
+}
+```
+
+#### `exec` — Run a shell command
+
+```json
+{
+  "type": "exec",
+  "phase": "pr-creation",
+  "commands": ["gh", "pr", "create", "--title", "feat: ...", "--body", "..."],
+  "setup_only": false
+}
+```
+
+#### `write_file` — Write content to disk
+
+```json
+{
+  "type": "write_file",
+  "phase": "phase-5",
+  "path": ".specs/20260401-fix-auth/tasks.md",
+  "content": "# Tasks\n\n..."
+}
+```
+
+#### `human_gate` — Wait for external human action
+
+```json
+{
+  "type": "human_gate",
+  "phase": "phase-5",
+  "name": "merge-external-pr",
+  "present_to_user": "Task 3 requires merging PR #456 in repo-b...",
+  "options": ["done", "skip", "abandon"]
+}
+```
+
+#### `done` — Pipeline complete
+
+```json
+{
+  "type": "done",
+  "summary": "Pipeline completed: 10 phases, 2 skipped",
+  "summary_path": ".specs/20260401-fix-auth/summary.md"
+}
+```
+
+### 4-Layer Prompt Assembly
+
+The `prompt` field in `spawn_agent` actions is assembled from four layers:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Layer 1: Agent Instructions                         │
+│   (loaded from agents/{name}.md)                    │
+├─────────────────────────────────────────────────────┤
+│ Layer 2: Input/Output Artifacts                     │
+│   ## Input Files                                    │
+│   - {workspace}/request.md                          │
+│   - {workspace}/analysis.md                         │
+│   ## Output File                                    │
+│   - {workspace}/design.md                           │
+├─────────────────────────────────────────────────────┤
+│ Layer 3: Repository Profile                         │
+│   ## Repository Context                             │
+│   Languages: Go (82%), TypeScript (15%)             │
+│   Build command: make build                         │
+│   Test command: go test ./...                       │
+│   Linter: golangci-lint                             │
+├─────────────────────────────────────────────────────┤
+│ Layer 4: Data Flywheel (cross-pipeline learning)    │
+│   ## Similar Past Pipelines                         │
+│   (BM25-scored matches from .specs/index.json)      │
+│   ## Past Review Patterns                           │
+│   (Levenshtein-merged review findings)              │
+│   ## AI Friction Points                             │
+│   (from past improvement.md reports)                │
+└─────────────────────────────────────────────────────┘
+```
+
+Layers 3 and 4 are injected only when data is available. Layer 2 lists file **paths** only — agents read the files themselves.
+
+---
+
+## 4. `pipeline_report_result` — Phase Result Recording
+
+Records metrics, validates artifacts, parses review verdicts, and advances pipeline state.
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workspace` | string | yes | Workspace path |
+| `phase` | string | yes | Phase ID (e.g., `"phase-3"`, `"phase-5"`) |
+| `tokens_used` | number | no | Tokens consumed by the phase |
+| `duration_ms` | number | no | Wall-clock duration in ms |
+| `model` | string | no | Model used (e.g., `"sonnet"`, `"opus"`) |
+| `setup_only` | boolean | no | True if exec was setup-only (no agent ran) |
+
+### Response
+
+```json
+{
+  "state_updated": true,
+  "artifact_written": "review-design.md",
+  "verdict_parsed": "APPROVE_WITH_NOTES",
+  "findings": [
+    { "severity": "MINOR", "description": "Consider adding error context to..." }
+  ],
+  "next_action_hint": "proceed",
+  "warning": "",
+  "display_message": ""
+}
+```
+
+### `next_action_hint` Values
+
+| Value | Meaning | Orchestrator Action |
+|-------|---------|-------------------|
+| `proceed` | Phase completed successfully | Continue to next `pipeline_next_action` |
+| `revision_required` | Review verdict is REVISE or FAIL | Present findings to user, re-run phase |
+| `setup_continue` | Internal setup action completed | Engine re-enters `NextAction` automatically |
+
+### Verdict Parsing
+
+The MCP server parses review verdicts from artifact content:
+
+| Phase | Verdicts | Source |
+|-------|----------|--------|
+| phase-3b (Design Review) | `APPROVE`, `APPROVE_WITH_NOTES`, `REVISE` | `review-design.md` |
+| phase-4b (Tasks Review) | `APPROVE`, `APPROVE_WITH_NOTES`, `REVISE` | `review-tasks.md` |
+| phase-6 (Code Review) | `PASS`, `PASS_WITH_NOTES`, `FAIL` | `review-{N}.md` |
+
+---
+
+## Orchestrator Loop — Complete Data Flow
+
+The following shows the exact sequence of MCP tool calls and their payloads for a single phase:
+
+```
+Orchestrator                          MCP Server                     Disk
+    │                                     │                           │
+    │─── pipeline_next_action ───────────►│                           │
+    │    { workspace, previous_* }        │── read state.json ───────►│
+    │                                     │◄── state data ────────────│
+    │                                     │── Engine.NextAction() ────│
+    │                                     │── read agent .md ────────►│
+    │                                     │── 4-layer prompt build ───│
+    │◄── { type: spawn_agent, ... } ──────│                           │
+    │                                     │                           │
+    │─── Agent(prompt=...) ──────────────────────────────────────────►│
+    │                                     │       (agent reads files) │
+    │◄── agent output ───────────────────────────────────────────────│
+    │                                     │                           │
+    │─── Write(analysis.md) ────────────────────────────────────────►│
+    │                                     │                           │
+    │─── pipeline_next_action ───────────►│                           │
+    │    { previous_action_complete: true  │── handleReportResult ────│
+    │      previous_tokens: 15000         │── validate artifact ─────►│
+    │      previous_duration_ms: 45000 }  │── parse verdict ──────────│
+    │                                     │── advance state ─────────►│
+    │◄── { type: spawn_agent, ... } ──────│   (next phase action)     │
+    │         (next phase)                │                           │
+```
+
+> **Key invariant**: The orchestrator never decides which phase to run. It executes the action returned by `pipeline_next_action` and reports the result back. All control flow lives in `Engine.NextAction()`.
+
 ## How the Pieces Connect
 
 ```

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -89,6 +89,12 @@ Skip this section entirely when the input artifacts do not include `analysis.md`
 ## Output Format
 
 ```
+## Summary
+
+(A concise description of what was implemented and why, written for PR reviewers.
+Derive from request.md and design.md. Use bullet points for key changes.
+This section is the primary content of the PR body — make it informative.)
+
 ## Verification Report
 
 ### Part A: Build Verification

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -60,6 +60,10 @@ export default withMermaid(
                     link: "/architecture/runtime-flow",
                   },
                   {
+                    text: "MCP Data Contracts",
+                    link: "/architecture/mcp-data-contracts",
+                  },
+                  {
                     text: "Pipeline Sequence",
                     link: "/architecture/pipeline-sequence",
                   },
@@ -206,6 +210,10 @@ export default withMermaid(
                   {
                     text: "ランタイムフロー",
                     link: "/ja/architecture/runtime-flow",
+                  },
+                  {
+                    text: "MCPデータコントラクト",
+                    link: "/ja/architecture/mcp-data-contracts",
                   },
                   {
                     text: "パイプラインシーケンス",

--- a/docs/architecture/mcp-data-contracts.md
+++ b/docs/architecture/mcp-data-contracts.md
@@ -1,0 +1,3 @@
+# MCP Data Contracts
+
+<!--@include: ../../template/sections/architecture/mcp-data-contracts.md-->

--- a/docs/ja/architecture/mcp-data-contracts.md
+++ b/docs/ja/architecture/mcp-data-contracts.md
@@ -1,0 +1,3 @@
+# MCPデータコントラクト
+
+<!--@include: ../../../template/sections/ja/architecture/mcp-data-contracts.md-->

--- a/mcp-server/cmd/main.go
+++ b/mcp-server/cmd/main.go
@@ -1,5 +1,5 @@
 // Package main is the entry point for the forge-state MCP server.
-// It wires together the StateManager, registers all 45 MCP tool handlers,
+// It wires together the StateManager, registers all 44 MCP tool handlers,
 // and starts the stdio transport.
 package main
 

--- a/mcp-server/internal/analytics/collector.go
+++ b/mcp-server/internal/analytics/collector.go
@@ -1,5 +1,6 @@
-// Package analytics aggregates pipeline history into cost/time predictions
+// aggregates pipeline history into cost/time predictions
 // and per-pipeline summaries.
+
 package analytics
 
 import (

--- a/mcp-server/internal/analytics/doc.go
+++ b/mcp-server/internal/analytics/doc.go
@@ -1,0 +1,17 @@
+// Package analytics aggregates pipeline history into cost/time predictions
+// and per-pipeline summaries.
+//
+// It provides three MCP tool handlers:
+//   - [AnalyticsEstimateHandler]: P50/P90 predictions for tokens, duration,
+//     and cost for a given (task_type, effort) combination.
+//   - [AnalyticsPipelineSummaryHandler]: token, duration, cost, and
+//     review-finding statistics for a single pipeline run.
+//   - [AnalyticsRepoDashboardHandler]: aggregate statistics across all
+//     pipeline runs in .specs/.
+//
+// The [Collector] reads state.json and phase-log entries from completed
+// pipeline workspaces; the [Estimator] computes percentile-based predictions
+// from collected data.
+//
+// Import direction: analytics → state (reads state.json schemas).
+package analytics

--- a/mcp-server/internal/analytics/reporter.go
+++ b/mcp-server/internal/analytics/reporter.go
@@ -1,4 +1,5 @@
-// Package analytics provides pipeline analytics: Collector, Estimator, and Reporter.
+// provides pipeline analytics: Collector, Estimator, and Reporter.
+
 package analytics
 
 import (

--- a/mcp-server/internal/ast/ast.go
+++ b/mcp-server/internal/ast/ast.go
@@ -1,4 +1,5 @@
-// Package ast provides tree-sitter-based AST parsing and code summarization.
+// provides tree-sitter-based AST parsing and code summarization.
+
 package ast
 
 import (

--- a/mcp-server/internal/ast/doc.go
+++ b/mcp-server/internal/ast/doc.go
@@ -1,0 +1,16 @@
+// Package ast provides source code analysis using tree-sitter parsers.
+//
+// Key capabilities:
+//   - [Summarize]: parse a source file and return a compact markdown summary
+//     of exported signatures (functions, types, methods).
+//   - [FindDefinition]: locate and return the full definition of a named
+//     symbol in a source file.
+//   - [BuildDependencyGraph]: walk a source tree and return a file-level
+//     import graph as JSON (nodes = files, edges = imports).
+//   - [FindCallSites]: identify files that call a given symbol via a
+//     two-pass import + call-site scan.
+//
+// Supports Go, TypeScript, and Python via tree-sitter grammars.
+//
+// Import direction: ast has no internal dependencies (leaf package).
+package ast

--- a/mcp-server/internal/events/bus.go
+++ b/mcp-server/internal/events/bus.go
@@ -1,4 +1,5 @@
-// Package events provides an in-process event bus for pipeline phase transition notifications.
+// provides an in-process event bus for pipeline phase transition notifications.
+
 package events
 
 import (

--- a/mcp-server/internal/events/doc.go
+++ b/mcp-server/internal/events/doc.go
@@ -1,0 +1,12 @@
+// Package events provides an in-process event bus for pipeline phase
+// transition notifications.
+//
+// The [Bus] broadcasts phase-start, phase-complete, and phase-fail events
+// to registered subscribers. It is used by the SSE handler to stream
+// real-time pipeline progress to external dashboards.
+//
+// The [SSEHandler] exposes an HTTP endpoint for Server-Sent Events when
+// the FORGE_EVENTS_PORT environment variable is set.
+//
+// Import direction: events → state (reads phase/status constants).
+package events

--- a/mcp-server/internal/history/doc.go
+++ b/mcp-server/internal/history/doc.go
@@ -1,0 +1,18 @@
+// Package history provides cross-pipeline learning by indexing and querying
+// completed pipeline runs stored in .specs/ directories.
+//
+// Key components:
+//   - [Index]: scans state.json and request.md files, builds [IndexEntry]
+//     records, persists them to .specs/history-index.json, and supports
+//     incremental updates using an indexedAt watermark.
+//   - [Search]: BM25-scored similarity search over indexed pipelines,
+//     returning ranked matches for a given query.
+//   - [Patterns]: extracts and Levenshtein-merges review findings from
+//     past review-*.md files into normalized [PatternEntry] records.
+//   - [Friction]: extracts AI friction points from past improvement.md
+//     files into [FrictionPoint] records.
+//   - [KnowledgeBase]: unified facade over Index, Patterns, and Friction
+//     for pipeline_report_result to update after each completed run.
+//
+// Import direction: history → state (reads state.json schemas).
+package history

--- a/mcp-server/internal/history/index.go
+++ b/mcp-server/internal/history/index.go
@@ -1,7 +1,8 @@
-// Package history provides a history index over completed/abandoned pipeline runs
+// provides a history index over completed/abandoned pipeline runs
 // stored in .specs/ directories. It scans state.json and request.md files,
 // builds IndexEntry records, persists them to .specs/history-index.json, and
 // supports incremental (differential) updates using an indexedAt watermark.
+
 package history
 
 import (

--- a/mcp-server/internal/history/search.go
+++ b/mcp-server/internal/history/search.go
@@ -1,4 +1,5 @@
-// Package history implements the history index and search over past pipeline runs.
+// implements the history index and search over past pipeline runs.
+
 package history
 
 import (

--- a/mcp-server/internal/indexer/doc.go
+++ b/mcp-server/internal/indexer/doc.go
@@ -1,0 +1,10 @@
+// Package indexer implements the specs index builder for the BM25 search
+// system.
+//
+// [BuildSpecsIndex] scans a .specs/ directory, extracts metadata from each
+// workspace (request summary, review feedback, implementation outcomes and
+// patterns), and writes an index.json file consumed by the search_patterns
+// MCP tool.
+//
+// Import direction: indexer → state (reads artifact filenames and state schemas).
+package indexer

--- a/mcp-server/internal/indexer/specs_index.go
+++ b/mcp-server/internal/indexer/specs_index.go
@@ -1,6 +1,7 @@
-// Package indexer implements the pure-Go replacement for build-specs-index.sh.
+// implements the pure-Go replacement for build-specs-index.sh.
 // It scans a .specs/ directory, extracts metadata from each workspace, and writes
 // an index.json file used by the BM25 search_patterns MCP tool.
+
 package indexer
 
 import (

--- a/mcp-server/internal/orchestrator/detection.go
+++ b/mcp-server/internal/orchestrator/detection.go
@@ -1,4 +1,5 @@
-// Package orchestrator provides pure-logic pipeline orchestration for the forge-state MCP server.
+// provides pure-logic pipeline orchestration for the forge-state MCP server.
+
 package orchestrator
 
 import "strings"

--- a/mcp-server/internal/orchestrator/doc.go
+++ b/mcp-server/internal/orchestrator/doc.go
@@ -1,0 +1,26 @@
+// Package orchestrator contains the deterministic pipeline engine that drives
+// all phase transitions in claude-forge.
+//
+// The central type is [Engine], whose [Engine.NextAction] method reads the
+// current [state.State] and returns a typed [Action] — spawn_agent,
+// checkpoint, exec, write_file, human_gate, or done. The LLM orchestrator
+// executes the returned action without making control-flow decisions.
+//
+// Key components:
+//   - [Engine]: the state machine. All dispatch decisions are deterministic
+//     functions of state.json. Handles effort-aware phase skipping, retry
+//     limits, artifact validation, and review verdict routing.
+//   - [Action]: the typed action struct returned by NextAction. Fields are
+//     populated based on the action type (see actions.go for type constants).
+//   - [Registry]: maps phase IDs to metadata (labels, skip rules per
+//     template). Initialised at package init from the declarative
+//     phaseRegistry table.
+//   - [DetectEffort]: heuristic effort detection from task text, Jira story
+//     points, and GitHub labels.
+//   - [DeriveBranchName]: generates deterministic branch names from spec names.
+//   - [ClassifyBranchType]: keyword-based branch type classification
+//     (feature/fix/refactor/docs/chore) from design content.
+//
+// Import direction: orchestrator → state (one-way). Never import tools or
+// history — that would create an import cycle. See go-package-layering.md.
+package orchestrator

--- a/mcp-server/internal/orchestrator/engine.go
+++ b/mcp-server/internal/orchestrator/engine.go
@@ -747,7 +747,9 @@ func derivePRTitle(st *state.State) string {
 // analysis.md and investigation.md are included (when present) to provide
 // context for the Improvement Report epilogue.
 func (*Engine) handleFinalSummary(st *state.State) (Action, error) {
-	inputs := []string{state.ArtifactDesign, state.ArtifactTasks}
+	// request.md is included so the verifier can generate a Summary section
+	// describing what was implemented (used as the PR body).
+	inputs := []string{state.ArtifactRequest, state.ArtifactDesign, state.ArtifactTasks}
 	if !slices.Contains(st.SkippedPhases, PhaseSeven) {
 		inputs = append([]string{state.ArtifactComprehensiveReview}, inputs...)
 	}

--- a/mcp-server/internal/orchestrator/phases.go
+++ b/mcp-server/internal/orchestrator/phases.go
@@ -1,5 +1,6 @@
-// Package orchestrator provides pure-logic building blocks for the pipeline engine.
+// provides pure-logic building blocks for the pipeline engine.
 // It may import the state/ package for state types used by the engine.
+
 package orchestrator
 
 import "github.com/hiromaily/claude-forge/mcp-server/internal/state"

--- a/mcp-server/internal/orchestrator/verdict.go
+++ b/mcp-server/internal/orchestrator/verdict.go
@@ -1,4 +1,5 @@
-// Package orchestrator provides pure-logic building blocks for the pipeline engine.
+// provides pure-logic building blocks for the pipeline engine.
+
 package orchestrator
 
 import (

--- a/mcp-server/internal/profile/analyzer.go
+++ b/mcp-server/internal/profile/analyzer.go
@@ -1,6 +1,7 @@
-// Package profile detects and caches repository metadata (languages, CI system,
+// detects and caches repository metadata (languages, CI system,
 // linter configs, build commands, etc.) for injection into agent prompts as
 // Layer 3 context.
+
 package profile
 
 import (

--- a/mcp-server/internal/profile/doc.go
+++ b/mcp-server/internal/profile/doc.go
@@ -1,0 +1,13 @@
+// Package profile detects and caches repository metadata for injection into
+// agent prompts as Layer 3 context.
+//
+// The [Analyzer] scans the repository root to detect languages, CI system,
+// linter configurations, and build/test/lint commands. Results are cached
+// in .specs/repo-profile.json and refreshed when the cache is older than
+// a configurable TTL.
+//
+// The profile_get MCP tool returns the cached profile, triggering
+// [Analyzer.AnalyzeOrUpdate] on first call.
+//
+// Import direction: profile has no internal dependencies (leaf package).
+package profile

--- a/mcp-server/internal/prompt/context.go
+++ b/mcp-server/internal/prompt/context.go
@@ -1,6 +1,7 @@
-// Package prompt assembles the 4-layer prompt passed to each pipeline agent.
+// assembles the 4-layer prompt passed to each pipeline agent.
 // It integrates agent base instructions, input artifacts, repository profile
 // context (Layer 3), and data flywheel history context (Layer 4).
+
 package prompt
 
 import (

--- a/mcp-server/internal/prompt/doc.go
+++ b/mcp-server/internal/prompt/doc.go
@@ -1,0 +1,15 @@
+// Package prompt assembles the 4-layer prompt passed to each pipeline agent
+// via the spawn_agent action.
+//
+// The four layers are:
+//   - Layer 1: Agent instructions (loaded from agents/{name}.md).
+//   - Layer 2: Input/output artifact paths for the current phase.
+//   - Layer 3: Repository profile context (languages, build commands, CI).
+//   - Layer 4: Data flywheel — cross-pipeline learning injected from the
+//     history package (similar pipelines, review patterns, friction points).
+//
+// The [Builder] constructs the final prompt string, applying a token budget
+// (8 000 tokens) to Layer 4 content to avoid exceeding context limits.
+//
+// Import direction: prompt → history (reads search results and patterns).
+package prompt

--- a/mcp-server/internal/search/bm25.go
+++ b/mcp-server/internal/search/bm25.go
@@ -1,5 +1,6 @@
-// Package search implements BM25 scoring for pattern index entries.
+// implements BM25 scoring for pattern index entries.
 // No external imports beyond Go stdlib (math, sort, strings, unicode).
+
 package search
 
 import (

--- a/mcp-server/internal/search/doc.go
+++ b/mcp-server/internal/search/doc.go
@@ -1,0 +1,11 @@
+// Package search implements BM25 scoring for the specs index.
+//
+// The [Scorer] takes a query string and a set of [Document] records
+// (loaded from .specs/index.json) and returns ranked results using
+// IDF-weighted term frequency with length normalisation (k1=1.5, b=0.75).
+//
+// Used by the search_patterns MCP tool to find similar past pipelines
+// and inject relevant history into agent prompts.
+//
+// Import direction: search has no internal dependencies (leaf package).
+package search

--- a/mcp-server/internal/state/constants.go
+++ b/mcp-server/internal/state/constants.go
@@ -1,7 +1,8 @@
-// Package state defines centralized constants for the forge-state pipeline.
+// defines centralized constants for the forge-state pipeline.
 // All phase identifiers, status values, task fields, artifact filenames, and
 // other magic strings are defined here to prevent typo-induced bugs and to
 // make rename operations safe (change once, compile-check everywhere).
+
 package state
 
 // ---------- Phase identifiers ----------

--- a/mcp-server/internal/state/doc.go
+++ b/mcp-server/internal/state/doc.go
@@ -1,0 +1,19 @@
+// Package state defines the pipeline state model and all centralized
+// constants for the forge-state MCP server.
+//
+// Key types:
+//   - [State]: the JSON-serializable pipeline state (state.json). Tracks
+//     current phase, status, effort, branch, tasks, skipped phases,
+//     revision counts, and phase-log entries.
+//   - [StateManager]: thread-safe read/write access to state.json on disk.
+//     All 26 state-management MCP commands (init, get, phase-start,
+//     phase-complete, set-effort, task-update, etc.) delegate to this type.
+//
+// All phase identifiers, status values, task fields, artifact filenames,
+// and other shared constants are defined here to prevent typo-induced bugs
+// and make rename operations safe (change once, compile-check everywhere).
+//
+// Import direction: state is the leaf of the internal dependency graph.
+// Every other internal package may import state; state imports nothing
+// from internal/.
+package state

--- a/mcp-server/internal/state/manager.go
+++ b/mcp-server/internal/state/manager.go
@@ -1,6 +1,7 @@
-// Package state implements the StateManager that provides all state mutation
+// implements the StateManager that provides all state mutation
 // and query operations for the forge-state MCP server. All 26 state-management
 // commands are implemented here, using a sync.RWMutex for concurrent access.
+
 package state
 
 import (

--- a/mcp-server/internal/state/state.go
+++ b/mcp-server/internal/state/state.go
@@ -1,6 +1,7 @@
-// Package state defines the State data model for the forge-state MCP server.
+// defines the State data model for the forge-state MCP server.
 // The Go struct field json tags must remain in 1:1 correspondence with the
 // state.json schema managed by the Go MCP server state package.
+
 package state
 
 // ValidPhases enumerates all legal phase identifiers.

--- a/mcp-server/internal/tools/analytics_estimate.go
+++ b/mcp-server/internal/tools/analytics_estimate.go
@@ -1,6 +1,7 @@
-// Package tools — analytics_estimate MCP handler.
+// analytics_estimate MCP handler.
 // AnalyticsEstimateHandler returns P50/P90 predictions for tokens, duration,
 // and cost for a given effort level.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/analytics_pipeline_summary.go
+++ b/mcp-server/internal/tools/analytics_pipeline_summary.go
@@ -1,6 +1,7 @@
-// Package tools — analytics_pipeline_summary MCP handler.
+// analytics_pipeline_summary MCP handler.
 // AnalyticsPipelineSummaryHandler returns token, duration, cost, and
 // review-finding statistics for a single pipeline run.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/analytics_repo_dashboard.go
+++ b/mcp-server/internal/tools/analytics_repo_dashboard.go
@@ -1,7 +1,8 @@
-// Package tools — analytics_repo_dashboard MCP handler.
+// analytics_repo_dashboard MCP handler.
 // AnalyticsRepoDashboardHandler returns aggregate statistics across all
 // pipeline runs in .specs/ (counts, averages, cost, review pass rate,
 // common findings).
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/artifact_guard.go
+++ b/mcp-server/internal/tools/artifact_guard.go
@@ -1,6 +1,7 @@
-// Package tools — artifact presence guards for pipeline_report_result.
+// artifact presence guards for pipeline_report_result.
 // Contains functions that check for missing impl/review artifact files
 // to enforce deterministic phase completion gates.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/ast_dependency_graph.go
+++ b/mcp-server/internal/tools/ast_dependency_graph.go
@@ -1,6 +1,7 @@
-// Package tools — ast_dependency_graph MCP tool handler.
+// ast_dependency_graph MCP tool handler.
 // AstDependencyGraphHandler walks a source tree and returns a file-level
 // import graph as JSON. It does not import or depend on the state package.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/ast_find_definition.go
+++ b/mcp-server/internal/tools/ast_find_definition.go
@@ -1,6 +1,7 @@
-// Package tools — ast_find_definition MCP tool handler.
+// ast_find_definition MCP tool handler.
 // AstFindDefinitionHandler searches for a named symbol declaration in a source file
 // using tree-sitter AST parsing. It does not import or depend on the state package.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/ast_impact_scope.go
+++ b/mcp-server/internal/tools/ast_impact_scope.go
@@ -1,7 +1,8 @@
-// Package tools — ast_impact_scope MCP tool handler.
+// ast_impact_scope MCP tool handler.
 // AstImpactScopeHandler identifies all files in a source tree that call a given
 // symbol, using a two-pass import-filter + call-site scan for Go and Bash, and
 // a single-pass call-site scan for TypeScript and Python.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/ast_summary.go
+++ b/mcp-server/internal/tools/ast_summary.go
@@ -1,7 +1,8 @@
-// Package tools — ast_summary MCP handler.
+// ast_summary MCP handler.
 // AstSummaryHandler exposes the ast.Summarize function as an MCP tool.
 // It accepts a file_path and an optional language parameter (auto-detected
 // from the file extension when omitted).
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/context_fetcher.go
+++ b/mcp-server/internal/tools/context_fetcher.go
@@ -1,4 +1,5 @@
-// Package tools — external context parsing and request.md construction.
+// external context parsing and request.md construction.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/doc.go
+++ b/mcp-server/internal/tools/doc.go
@@ -1,0 +1,37 @@
+// Package tools implements all 44 MCP tool handlers registered by the
+// forge-state server.
+//
+// The handlers are organised into categories:
+//
+// Pipeline lifecycle (4 tools):
+//   - [PipelineInitHandler]: input parsing and resume detection.
+//   - [PipelineInitWithContextHandler]: three-call confirmation flow
+//     (effort detection → optional discussion → workspace initialisation).
+//   - [PipelineNextActionHandler]: reads state, calls [orchestrator.Engine],
+//     enriches spawn_agent prompts with 4-layer assembly, and returns
+//     typed actions.
+//   - [PipelineReportResultHandler]: records phase metrics, validates
+//     artifacts, parses review verdicts, and advances pipeline state.
+//
+// State management (26 tools):
+//   - init, get, phase-start, phase-complete, phase-fail, checkpoint,
+//     abandon, skip-phase, task-init, task-update, revision-bump,
+//     inline-revision-bump, set-revision-pending, clear-revision-pending,
+//     set-branch, set-effort, set-flow-template, set-auto-approve,
+//     set-skip-pr, set-debug, set-use-current-branch, phase-log,
+//     phase-stats, resume-info, refresh-index.
+//
+// Code analysis (4 tools): ast_summary, ast_find_definition,
+// dependency_graph, impact_scope.
+//
+// Validation (2 tools): validate_input, validate_artifact.
+//
+// History & analytics (8 tools): search_patterns, subscribe_events,
+// history_search, history_get_patterns, history_get_friction_map,
+// analytics_pipeline_summary, analytics_repo_dashboard, analytics_estimate.
+//
+// All handlers are registered in [RegisterAll] (registry.go).
+//
+// Import direction: tools → orchestrator → state (one-way DAG).
+// tools also imports history, profile, prompt, validation, and events.
+package tools

--- a/mcp-server/internal/tools/git_ops.go
+++ b/mcp-server/internal/tools/git_ops.go
@@ -1,6 +1,7 @@
-// Package tools — git operations for batch and final commit absorption.
+// git operations for batch and final commit absorption.
 // These functions are called internally by PipelineNextActionHandler to execute
 // git operations that were previously delegated to the orchestrator via exec actions.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/guards.go
+++ b/mcp-server/internal/tools/guards.go
@@ -1,7 +1,8 @@
-// Package tools implements guard functions that re-implement the blocking and
+// implements guard functions that re-implement the blocking and
 // warning guards from scripts/pre-tool-hook.sh (Rules 3a–3j) inside the Go MCP
 // tool handlers.  Blocking guards return a non-nil error; warning-only guards
 // return a non-empty string message and never return an error.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/handlers.go
+++ b/mcp-server/internal/tools/handlers.go
@@ -1,8 +1,9 @@
-// Package tools implements MCP tool handlers that delegate to StateManager
+// implements MCP tool handlers that delegate to StateManager
 // methods and enforce guard preconditions.
 //
 // Blocking guards return an MCP error response (IsError = true).
 // Non-blocking warnings are included as a "warning" key in the JSON content.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/helpers.go
+++ b/mcp-server/internal/tools/helpers.go
@@ -1,6 +1,7 @@
-// Package tools — shared helper functions for MCP tool handlers.
+// shared helper functions for MCP tool handlers.
 // These helpers eliminate repeated parameter extraction, state loading,
 // and nil-safety patterns across handler files.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/history_friction.go
+++ b/mcp-server/internal/tools/history_friction.go
@@ -1,6 +1,7 @@
-// Package tools — history_get_friction_map MCP handler.
+// history_get_friction_map MCP handler.
 // HistoryGetFrictionMapHandler exposes the FrictionMap query as an MCP tool.
 // It returns accumulated friction points extracted from improvement reports.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/history_patterns.go
+++ b/mcp-server/internal/tools/history_patterns.go
@@ -1,6 +1,7 @@
-// Package tools — history_get_patterns MCP handler.
+// history_get_patterns MCP handler.
 // HistoryGetPatternsHandler exposes the PatternAccumulator query as an MCP tool.
 // It returns accumulated review finding patterns filtered by agent and/or severity.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/history_search.go
+++ b/mcp-server/internal/tools/history_search.go
@@ -1,7 +1,8 @@
-// Package tools — history_search MCP handler.
+// history_search MCP handler.
 // HistorySearchHandler exposes the history index search as an MCP tool.
 // It queries past pipeline runs from the history index using BM25 scoring
 // and returns ranked results with metadata and design excerpts.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/phase_transition.go
+++ b/mcp-server/internal/tools/phase_transition.go
@@ -1,6 +1,7 @@
-// Package tools — phase transition helpers for pipeline_report_result.
+// phase transition helpers for pipeline_report_result.
 // Contains phase-5 and phase-4 specific transition logic extracted from
 // determineTransition for focused readability.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/pipeline_init.go
+++ b/mcp-server/internal/tools/pipeline_init.go
@@ -1,7 +1,8 @@
-// Package tools — pipeline_init MCP handler.
+// pipeline_init MCP handler.
 // PipelineInitHandler is a pure detection tool: it parses the raw arguments string
 // and returns structured data about the pipeline to initialize. It has no side effects
 // on StateManager — no sm.Init or setter calls are made.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/pipeline_init_with_context.go
+++ b/mcp-server/internal/tools/pipeline_init_with_context.go
@@ -1,4 +1,4 @@
-// Package tools — pipeline_init_with_context MCP handler.
+// pipeline_init_with_context MCP handler.
 // Implements the three-call confirmation flow.
 // First call (neither user_confirmation nor discussion_answers present): detects effort and returns
 //
@@ -13,6 +13,7 @@
 //	workspace, writes state.json + request.md.
 //
 // DISCRIMINATOR ORDER: discussion_answers is checked BEFORE user_confirmation to prevent shadowing.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/pipeline_init_with_context.go
+++ b/mcp-server/internal/tools/pipeline_init_with_context.go
@@ -52,14 +52,20 @@ type PipelineInitWithContextResult struct {
 	NeedsDiscussion       *DiscussionPrompt       `json:"needs_discussion,omitempty"`
 }
 
+// EffortOption describes a single effort level with its skip list and recommended flag.
+type EffortOption struct {
+	SkippedPhases []orchestrator.SkipLabel `json:"skipped_phases"`
+	Recommended   bool                     `json:"recommended"`
+}
+
 // UserConfirmationPrompt holds the detected values to present to the user.
 type UserConfirmationPrompt struct {
-	DetectedEffort      string                              `json:"detected_effort"`
-	EffortOptions       map[string][]orchestrator.SkipLabel `json:"effort_options"`
-	CurrentBranch       string                              `json:"current_branch"`
-	IsMainBranch        bool                                `json:"is_main_branch"`
-	Message             string                              `json:"message"`
-	EnrichedRequestBody string                              `json:"enriched_request_body,omitempty"`
+	DetectedEffort      string                  `json:"detected_effort"`
+	EffortOptions       map[string]EffortOption  `json:"effort_options"`
+	CurrentBranch       string                  `json:"current_branch"`
+	IsMainBranch        bool                    `json:"is_main_branch"`
+	Message             string                  `json:"message"`
+	EnrichedRequestBody string                  `json:"enriched_request_body,omitempty"`
 }
 
 // pipelineFlags holds parsed flag fields from the flags parameter.
@@ -189,10 +195,11 @@ func buildUserConfirmationPrompt(workspace string, extCtx externalContext, flags
 	effort := orchestrator.DetectEffort(flags.EffortOverride, extCtx.JiraStoryPoints, combinedText)
 
 	// Build EffortOptions for all three valid efforts with human-readable labels.
-	effortOptions := map[string][]orchestrator.SkipLabel{
-		"S": orchestrator.SkipsWithLabelsForEffort("S"),
-		"M": orchestrator.SkipsWithLabelsForEffort("M"),
-		"L": orchestrator.SkipsWithLabelsForEffort("L"),
+	// The detected effort is marked as recommended so the orchestrator renders it deterministically.
+	effortOptions := map[string]EffortOption{
+		"S": {SkippedPhases: orchestrator.SkipsWithLabelsForEffort("S"), Recommended: effort == "S"},
+		"M": {SkippedPhases: orchestrator.SkipsWithLabelsForEffort("M"), Recommended: effort == "M"},
+		"L": {SkippedPhases: orchestrator.SkipsWithLabelsForEffort("L"), Recommended: effort == "L"},
 	}
 
 	// Determine branch state for the user confirmation prompt.

--- a/mcp-server/internal/tools/pipeline_init_with_context.go
+++ b/mcp-server/internal/tools/pipeline_init_with_context.go
@@ -263,9 +263,15 @@ func handleSecondCall(
 
 	// Derive specName and optionally rename workspace for better readability.
 	// Priority order: external context (Jira/GitHub) > LLM-provided slug > auto-derived slug.
+	// When LLM slug is provided alongside a source_id (GitHub issue number or Jira key),
+	// prepend the source_id to the slug so it appears in the branch name and PR title.
 	workspace = refineWorkspacePath(workspace, extCtx)
 	if uc.WorkspaceSlug != "" {
-		workspace = applyWorkspaceSlug(workspace, uc.WorkspaceSlug)
+		slug := uc.WorkspaceSlug
+		if extCtx.SourceID != "" {
+			slug = extCtx.SourceID + "-" + slug
+		}
+		workspace = applyWorkspaceSlug(workspace, slug)
 	}
 	specName := deriveSpecName(workspace)
 

--- a/mcp-server/internal/tools/pipeline_init_with_context_test.go
+++ b/mcp-server/internal/tools/pipeline_init_with_context_test.go
@@ -799,6 +799,95 @@ func TestTopLevelSourceIDRefinement(t *testing.T) {
 	}
 }
 
+// ---------- TestSourceIDPrependedToWorkspaceSlug ----------
+
+func TestSourceIDPrependedToWorkspaceSlug(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		sourceID      string
+		slug          string
+		extCtx        map[string]any
+		wantSpecName  string
+		wantBranch    string
+	}{
+		{
+			name:     "github_issue_with_slug",
+			sourceID: "42",
+			slug:     "fix-auth-timeout",
+			extCtx: map[string]any{
+				"github_title": "Fix auth timeout",
+				"github_body":  "requests timeout",
+			},
+			wantSpecName: "42-fix-auth-timeout",
+			wantBranch:   "feature/42-fix-auth-timeout",
+		},
+		{
+			name:     "jira_issue_with_slug",
+			sourceID: "SOA-2883",
+			slug:     "skip-minutes-job",
+			extCtx: map[string]any{
+				"jira_summary":     "Skip minutes job without integration",
+				"jira_description": "desc",
+			},
+			wantSpecName: "soa-2883-skip-minutes-job",
+			wantBranch:   "feature/soa-2883-skip-minutes-job",
+		},
+		{
+			name:     "text_source_no_source_id",
+			sourceID: "",
+			slug:     "add-user-auth",
+			extCtx:   map[string]any{},
+			wantSpecName: "add-user-auth",
+			wantBranch:   "feature/add-user-auth",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			parentDir := t.TempDir()
+			wsDir := filepath.Join(parentDir, "20260330-placeholder")
+
+			sm := newPIWCSM()
+			h := PipelineInitWithContextHandler(sm)
+
+			args := map[string]any{
+				"workspace":        wsDir,
+				"external_context": tc.extCtx,
+				"flags":            map[string]any{},
+				"user_confirmation": map[string]any{
+					"effort":         "S",
+					"workspace_slug": tc.slug,
+				},
+			}
+			if tc.sourceID != "" {
+				args["source_id"] = tc.sourceID
+			}
+
+			res := callTool(t, h, args)
+			if res.IsError {
+				t.Fatalf("unexpected MCP error: %v", textContent(res))
+			}
+
+			result := parsePIWCResult(t, textContent(res))
+
+			s, err := state.ReadState(result.Workspace)
+			if err != nil {
+				t.Fatalf("ReadState: %v", err)
+			}
+			if s.SpecName != tc.wantSpecName {
+				t.Errorf("SpecName = %q, want %q", s.SpecName, tc.wantSpecName)
+			}
+			if result.Branch != tc.wantBranch {
+				t.Errorf("Branch = %q, want %q", result.Branch, tc.wantBranch)
+			}
+		})
+	}
+}
+
 // ---------- TestDiscussionMode ----------
 
 // TestDiscussFirstCallTextSourceReturnsNeedsDiscussion verifies that handleFirstCall

--- a/mcp-server/internal/tools/pipeline_init_with_context_test.go
+++ b/mcp-server/internal/tools/pipeline_init_with_context_test.go
@@ -129,14 +129,23 @@ func TestPipelineInitWithContextFirstCallEffortOptions(t *testing.T) {
 			wantS := orchestrator.SkipsWithLabelsForEffort("S")
 			wantM := orchestrator.SkipsWithLabelsForEffort("M")
 			wantL := orchestrator.SkipsWithLabelsForEffort("L")
-			if !skipLabelSliceEqual(nuc.EffortOptions["S"], wantS) {
-				t.Errorf("effort_options[S] = %v, want %v", nuc.EffortOptions["S"], wantS)
+			if !skipLabelSliceEqual(nuc.EffortOptions["S"].SkippedPhases, wantS) {
+				t.Errorf("effort_options[S].skipped_phases = %v, want %v", nuc.EffortOptions["S"].SkippedPhases, wantS)
 			}
-			if !skipLabelSliceEqual(nuc.EffortOptions["M"], wantM) {
-				t.Errorf("effort_options[M] = %v, want %v", nuc.EffortOptions["M"], wantM)
+			if !skipLabelSliceEqual(nuc.EffortOptions["M"].SkippedPhases, wantM) {
+				t.Errorf("effort_options[M].skipped_phases = %v, want %v", nuc.EffortOptions["M"].SkippedPhases, wantM)
 			}
-			if !skipLabelSliceEqual(nuc.EffortOptions["L"], wantL) {
-				t.Errorf("effort_options[L] = %v, want %v", nuc.EffortOptions["L"], wantL)
+			if !skipLabelSliceEqual(nuc.EffortOptions["L"].SkippedPhases, wantL) {
+				t.Errorf("effort_options[L].skipped_phases = %v, want %v", nuc.EffortOptions["L"].SkippedPhases, wantL)
+			}
+
+			// Verify recommended flag matches detected_effort
+			for _, key := range []string{"S", "M", "L"} {
+				opt := nuc.EffortOptions[key]
+				wantRec := key == tc.wantEffort
+				if opt.Recommended != wantRec {
+					t.Errorf("effort_options[%s].recommended = %v, want %v", key, opt.Recommended, wantRec)
+				}
 			}
 
 			if nuc.Message == "" {

--- a/mcp-server/internal/tools/pipeline_next_action.go
+++ b/mcp-server/internal/tools/pipeline_next_action.go
@@ -1,6 +1,7 @@
-// Package tools — pipeline_next_action MCP handler.
+// pipeline_next_action MCP handler.
 // Delegates to Engine.NextAction() and enriches spawn_agent prompts
 // with agent .md file contents and input artifact file paths (not contents).
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/pipeline_report_result.go
+++ b/mcp-server/internal/tools/pipeline_report_result.go
@@ -1,5 +1,6 @@
-// Package tools — pipeline_report_result MCP handler.
+// pipeline_report_result MCP handler.
 // Records phase-log entry, validates artifacts, parses verdict, and advances state.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/profile_get.go
+++ b/mcp-server/internal/tools/profile_get.go
@@ -1,6 +1,7 @@
-// Package tools — profile_get MCP handler.
+// profile_get MCP handler.
 // ProfileGetHandler returns the repository profile as JSON.
 // The profile is computed once at server startup and cached for 7 days.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/registry.go
+++ b/mcp-server/internal/tools/registry.go
@@ -1,5 +1,6 @@
-// Package tools registers all 44 MCP tool handlers with the MCP server.
+// registers all 44 MCP tool handlers with the MCP server.
 // Tool names use underscores (MCP protocol requirement; hyphens are not permitted).
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/response_helpers.go
+++ b/mcp-server/internal/tools/response_helpers.go
@@ -1,8 +1,9 @@
-// Package tools — response construction helpers and low-level utilities used by
+// response construction helpers and low-level utilities used by
 // MCP tool handlers.
 //
 // Extracted from handlers.go to keep that file focused on the 26 *Handler
 // functions only.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/search_patterns.go
+++ b/mcp-server/internal/tools/search_patterns.go
@@ -1,7 +1,8 @@
-// Package tools — search_patterns MCP handler.
+// search_patterns MCP handler.
 // SearchPatternsHandler exposes BM25 scoring of .specs/index.json as an MCP tool.
 // It reads the workspace's request.md as the query, strips YAML frontmatter,
 // calls search.Score, and formats results as structured markdown.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/subscribe_events.go
+++ b/mcp-server/internal/tools/subscribe_events.go
@@ -1,7 +1,8 @@
-// Package tools — subscribe_events MCP tool handler.
+// subscribe_events MCP tool handler.
 // SubscribeEventsHandler is a discovery-only tool that returns the SSE endpoint
 // URL when the events server is configured, or an informational message otherwise.
 // It does not import or depend on the state package.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/task_ops.go
+++ b/mcp-server/internal/tools/task_ops.go
@@ -1,5 +1,6 @@
-// Package tools — task_ops.go implements ParseTasksMd and executeTaskInit
+// task_ops.go implements ParseTasksMd and executeTaskInit
 // for absorbing the task_init action type inside PipelineNextActionHandler (P2).
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/validate_artifact.go
+++ b/mcp-server/internal/tools/validate_artifact.go
@@ -1,7 +1,8 @@
-// Package tools — validate_artifact MCP handler.
+// validate_artifact MCP handler.
 // ValidateArtifactHandler exposes validation.ValidateArtifacts as an MCP tool.
 // It always returns the result slice serialised as a JSON array via okJSON.
 // Missing workspace or phase parameters return an errorf response.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/validate_input.go
+++ b/mcp-server/internal/tools/validate_input.go
@@ -1,7 +1,8 @@
-// Package tools — validate_input MCP handler.
+// validate_input MCP handler.
 // ValidateInputHandler exposes validation.ValidateInput as an MCP tool.
 // It always returns a JSON-serialised InputResult via okJSON, never an MCP error,
 // even when the input is empty or invalid.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/verdict_parser.go
+++ b/mcp-server/internal/tools/verdict_parser.go
@@ -1,6 +1,7 @@
-// Package tools — verdict parsing helpers for pipeline_report_result.
+// verdict parsing helpers for pipeline_report_result.
 // Contains lookup maps and the functions that determine state transitions
 // based on review phase verdicts.
+
 package tools
 
 import (

--- a/mcp-server/internal/tools/workspace_init.go
+++ b/mcp-server/internal/tools/workspace_init.go
@@ -1,4 +1,5 @@
-// Package tools — workspace initialisation helpers.
+// workspace initialisation helpers.
+
 package tools
 
 import (

--- a/mcp-server/internal/validation/artifact.go
+++ b/mcp-server/internal/validation/artifact.go
@@ -1,5 +1,6 @@
-// Package validation implements input and artifact validation logic for
+// implements input and artifact validation logic for
 // the forge-state MCP server.
+
 package validation
 
 import (

--- a/mcp-server/internal/validation/doc.go
+++ b/mcp-server/internal/validation/doc.go
@@ -1,0 +1,15 @@
+// Package validation implements input and artifact validation logic for
+// the forge-state MCP server.
+//
+// Key functions:
+//   - [ValidateInput]: validates the raw pipeline input string (empty,
+//     too-short, URL format) and parses it into a [ParsedInput] with
+//     source type, core text, bare flags, and key-value flags.
+//   - [ValidateArtifact]: checks that the expected artifact file exists
+//     for a given phase and meets content constraints (non-empty, minimum
+//     length, required sections).
+//   - [ValidateWorkflowRules]: parses .specs/instructions.md for
+//     declarative workflow rules and validates tasks.md against them.
+//
+// Import direction: validation → state (reads phase and artifact constants).
+package validation

--- a/mcp-server/internal/validation/input.go
+++ b/mcp-server/internal/validation/input.go
@@ -1,6 +1,7 @@
-// Package validation provides input and artifact validation logic for the
+// provides input and artifact validation logic for the
 // claude-forge MCP server. It replaces the shell-script validate-input.sh and
 // the pre-tool-hook artifact checks with typed Go functions.
+
 package validation
 
 import (

--- a/mcp-server/internal/validation/workflow_rules.go
+++ b/mcp-server/internal/validation/workflow_rules.go
@@ -1,10 +1,11 @@
-// Package validation — workflow_rules.go implements .specs/instructions.md
+// workflow_rules.go implements .specs/instructions.md
 // loading and validation for phase-4 task-decomposer output.
 //
 // See docs/superpowers/specs/2026-04-10-workflow-instructions-design.md for
 // the design rationale. The evaluator runs at phase-4 completion (before
 // PhaseComplete) and returns Violations for tasks that match a rule's
 // `when` conditions but do not have mode: human_gate set.
+
 package validation
 
 import (

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -48,8 +48,10 @@ Example: `/forge 20260401-effort-only-flow`
    **Effort/branch confirmation step** (applies after either path above):
    Present **all** of the following to the user in a **single prompt** (use AskUserQuestion
    with multiple questions):
-   1. **Effort level**: the detected `detected_effort` and all three effort options from
-      `effort_options` (S, M, L — each with their skipped phases, using the `label` field).
+   1. **Effort level**: present all three effort options from `effort_options`
+      (S, M, L — each with their skipped phases, using the `label` field).
+      Mark **only** the option matching `detected_effort` as "(Recommended)".
+      Do not mark any other option as recommended.
    2. **Branch decision**: based on `current_branch` and `is_main_branch` from the response:
       - If `is_main_branch` is true: inform the user a new branch will be created (no question needed).
       - If `is_main_branch` is false: ask whether to use the current branch or create a new one.

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -57,6 +57,8 @@ Example: `/forge 20260401-effort-only-flow`
    ASCII only) that summarises the task — e.g. `"add-user-auth-endpoint"` or
    `"fix-report-export-timeout"`. If the input is in a non-English language, translate
    the core intent into English for the slug.
+   **Do not include the issue number** (GitHub `#N` or Jira `PROJ-123`) in the slug —
+   the server prepends `source_id` automatically when present.
    Then call `mcp__forge-state__pipeline_init_with_context` again with the same parameters plus
    `user_confirmation={effort: <confirmed>, workspace_slug: <slug>, use_current_branch: <bool>}`.
    If `needs_user_confirmation.enriched_request_body` is non-empty (from the discussion path),

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -49,9 +49,9 @@ Example: `/forge 20260401-effort-only-flow`
    Present **all** of the following to the user in a **single prompt** (use AskUserQuestion
    with multiple questions):
    1. **Effort level**: present all three effort options from `effort_options`
-      (S, M, L — each with their skipped phases, using the `label` field).
-      Mark **only** the option matching `detected_effort` as "(Recommended)".
-      Do not mark any other option as recommended.
+      (S, M, L — each with `skipped_phases` using the `label` field).
+      Each option has a `recommended` boolean — mark the one where
+      `recommended` is `true` as "(Recommended)".
    2. **Branch decision**: based on `current_branch` and `is_main_branch` from the response:
       - If `is_main_branch` is true: inform the user a new branch will be created (no question needed).
       - If `is_main_branch` is false: ask whether to use the current branch or create a new one.

--- a/template/INDEX.md
+++ b/template/INDEX.md
@@ -8,7 +8,7 @@
 | --- | --- | --- |
 | pages/README.tpl.md | README.md | 20 |
 | pages/CLAUDE.tpl.md | CLAUDE.md | 12 |
-| pages/ARCHITECTURE.tpl.md | ARCHITECTURE.md | 9 |
+| pages/ARCHITECTURE.tpl.md | ARCHITECTURE.md | 10 |
 | pages/SETUP.tpl.md | SETUP.md | 2 |
 | pages/ai-agents/claude/rules/docs.tpl.md | .claude/rules/docs.md | 1 |
 | pages/ai-agents/claude/rules/git.tpl.md | .claude/rules/git.md | 1 |
@@ -29,6 +29,7 @@
 | sections/architecture/how-it-works.md | ARCHITECTURE, README |
 | sections/architecture/how-the-pieces-connect.md | ARCHITECTURE, CLAUDE |
 | sections/architecture/human-interaction.md | ARCHITECTURE, README |
+| sections/architecture/mcp-data-contracts.md | ARCHITECTURE |
 | sections/architecture/mcp-driven-pipeline-control.md | ARCHITECTURE, README |
 | sections/architecture/pipeline-flow.md | ARCHITECTURE, README |
 | sections/architecture/pipeline-phase-execution-by-effort-level.md | ARCHITECTURE, README |
@@ -124,6 +125,7 @@
 | sections/ja/architecture/guard-catalogue.md | Not referenced by any template |
 | sections/ja/architecture/hooks.md | Not referenced by any template |
 | sections/ja/architecture/human-interaction.md | Not referenced by any template |
+| sections/ja/architecture/mcp-data-contracts.md | Not referenced by any template |
 | sections/ja/architecture/overview-content.md | Not referenced by any template |
 | sections/ja/architecture/pipeline-flow-guide.md | Not referenced by any template |
 | sections/ja/architecture/pipeline-flow.md | Not referenced by any template |

--- a/template/pages/ARCHITECTURE.tpl.md
+++ b/template/pages/ARCHITECTURE.tpl.md
@@ -6,6 +6,8 @@
 
 <!-- @include: ../sections/architecture/mcp-driven-pipeline-control.md -->
 
+<!-- @include: ../sections/architecture/mcp-data-contracts.md -->
+
 <!-- @include: ../sections/architecture/how-the-pieces-connect.md -->
 
 <!-- @include: ../sections/architecture/pipeline-flow.md -->

--- a/template/sections/architecture/mcp-data-contracts.md
+++ b/template/sections/architecture/mcp-data-contracts.md
@@ -1,0 +1,434 @@
+# MCP Data Contracts
+
+This document specifies the exact JSON payloads exchanged between the Claude orchestrator (SKILL.md) and the Go MCP server (`forge-state-mcp`) during a pipeline run. These four tools drive the entire pipeline lifecycle.
+
+> **Source of truth**: The Go structs in `mcp-server/internal/tools/` and `mcp-server/internal/orchestrator/actions.go`. This document mirrors those definitions — update both when changing schemas.
+
+---
+
+## 1. `pipeline_init` — Input Parsing & Resume Detection
+
+Pure detection tool. Parses the raw `/forge` arguments, detects source type, checks for resume candidates. **No side effects on state.**
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `arguments` | string | yes | Raw arguments string passed to `/forge` |
+| `current_branch` | string | no | Output of `git branch --show-current` |
+
+### Response
+
+**Resume path** (input matches existing `.specs/` directory):
+
+```json
+{
+  "resume_mode": "auto",
+  "workspace": ".specs/20260330-fix-auth-timeout",
+  "instruction": "call state_resume_info"
+}
+```
+
+**New pipeline path**:
+
+```json
+{
+  "workspace": ".specs/20260401-https-github-com-owner-repo-issues-42",
+  "spec_name": "https-github-com-owner-repo-issues-42",
+  "source_type": "github_issue",
+  "source_url": "https://github.com/owner/repo/issues/42",
+  "source_id": "42",
+  "core_text": "https://github.com/owner/repo/issues/42",
+  "flags": {
+    "auto": false,
+    "skip_pr": false,
+    "debug": false,
+    "discuss": false,
+    "effort_override": null,
+    "current_branch": "main"
+  },
+  "fetch_needed": {
+    "type": "github",
+    "fields": ["labels", "title", "body"],
+    "instruction": "fetch github issue fields before calling pipeline_init_with_context"
+  }
+}
+```
+
+**Error path** (invalid input):
+
+```json
+{
+  "errors": ["input too short: minimum 3 characters required"]
+}
+```
+
+### `source_type` Values
+
+| Value | Trigger |
+|-------|---------|
+| `github_issue` | URL matching `github.com/.../issues/\d+` |
+| `jira_issue` | URL matching `*.atlassian.net/browse/...` |
+| `text` | Plain text (default) |
+| `workspace` | Input contains `.specs/` |
+
+---
+
+## 2. `pipeline_init_with_context` — Three-Call Confirmation Flow
+
+Implements a multi-call handshake: detect effort → (optional: discuss) → confirm & initialise workspace.
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workspace` | string | yes | Workspace path from `pipeline_init` |
+| `source_id` | string | no | Source identifier (e.g., `"42"`, `"SOA-123"`) |
+| `source_url` | string | no | Original URL (GitHub/Jira) |
+| `external_context` | object | no | Fetched GitHub/Jira fields (see below) |
+| `flags` | object | no | Parsed flags from `pipeline_init` |
+| `task_text` | string | no | Original task text (text source only) |
+| `user_confirmation` | object | no | Confirmed effort + branch decision (second call) |
+| `discussion_answers` | string | no | User answers to discussion questions |
+
+**`external_context` object:**
+
+```json
+{
+  "github_labels": ["bug", "priority-high"],
+  "github_title": "Fix auth timeout in middleware",
+  "github_body": "requests timeout after 30s",
+  "jira_issue_type": "Bug",
+  "jira_story_points": 3,
+  "jira_summary": "Skip minutes job without integration",
+  "jira_description": "..."
+}
+```
+
+**`user_confirmation` object (confirmation call):**
+
+```json
+{
+  "effort": "M",
+  "workspace_slug": "fix-auth-timeout",
+  "use_current_branch": false,
+  "enriched_request_body": "..."
+}
+```
+
+### Response — First Call (effort detection)
+
+Returns `needs_user_confirmation` for the orchestrator to present to the user:
+
+```json
+{
+  "needs_user_confirmation": {
+    "detected_effort": "M",
+    "effort_options": {
+      "S": {
+        "skipped_phases": [
+          { "phase_id": "phase-2", "label": "Investigation" },
+          { "phase_id": "phase-3b", "label": "Design Review" }
+        ],
+        "recommended": false
+      },
+      "M": {
+        "skipped_phases": [
+          { "phase_id": "phase-4b", "label": "Tasks Review" },
+          { "phase_id": "checkpoint-b", "label": "Human Reviews Tasks" }
+        ],
+        "recommended": true
+      },
+      "L": {
+        "skipped_phases": [],
+        "recommended": false
+      }
+    },
+    "current_branch": "main",
+    "is_main_branch": true,
+    "enriched_request_body": "implement login feature",
+    "message": "Detected effort=\"M\". ..."
+  }
+}
+```
+
+### Response — First Call with `--discuss` (text source only)
+
+```json
+{
+  "needs_discussion": {
+    "questions": [
+      "What is the main goal of this change?",
+      "Are there any constraints or dependencies?",
+      "What is the expected scope of changes?"
+    ],
+    "message": "Please answer the following questions..."
+  }
+}
+```
+
+### Response — Confirmation Call (workspace finalised)
+
+```json
+{
+  "ready": true,
+  "workspace": ".specs/20260401-42-fix-auth-timeout",
+  "effort": "M",
+  "flow_template": "standard",
+  "skipped_phases": ["phase-4b", "checkpoint-b"],
+  "request_md_content": "---\nsource_type: github_issue\n...",
+  "branch": "feature/42-fix-auth-timeout",
+  "create_branch": true
+}
+```
+
+### Call Discriminator
+
+| `discussion_answers` | `user_confirmation` | Path |
+|---|---|---|
+| absent | absent | First call → detect effort |
+| present | absent | Discussion call → enrich body |
+| absent | present | Confirmation call → init workspace |
+| present | present | **Error** — ambiguous |
+
+---
+
+## 3. `pipeline_next_action` — Action Dispatch
+
+The core loop driver. Reads `state.json`, runs `Engine.NextAction()` deterministically, returns a typed action for the orchestrator to execute.
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workspace` | string | yes | Workspace path |
+| `previous_action_complete` | boolean | no | True after agent/exec/write_file completes |
+| `previous_tokens` | number | no | Token count from previous action |
+| `previous_duration_ms` | number | no | Duration in ms of previous action |
+| `previous_model` | string | no | Model used for previous action |
+| `previous_setup_only` | boolean | no | True if previous exec was setup-only |
+| `user_response` | string | no | User response for checkpoint actions |
+
+### Response Structure
+
+Every response wraps an `Action` with optional metadata:
+
+```json
+{
+  "type": "spawn_agent",
+  "warning": "",
+  "display_message": "Phase 1: Situation Analysis",
+  "report_result": null,
+  ...action-specific fields...
+}
+```
+
+When `report_result` is non-null, the engine has recorded a phase result internally (this happens for `pipeline_report_result` calls routed through `pipeline_next_action`):
+
+```json
+{
+  "report_result": {
+    "next_action_hint": "revision_required",
+    "verdict_parsed": "REVISE",
+    "findings": [
+      { "severity": "CRITICAL", "description": "Missing error handling for..." }
+    ],
+    "warning": "",
+    "display_message": ""
+  }
+}
+```
+
+### Action Types
+
+#### `spawn_agent` — Dispatch an LLM subagent
+
+```json
+{
+  "type": "spawn_agent",
+  "agent": "situation-analyst",
+  "prompt": "...4-layer assembled prompt...",
+  "model": "sonnet",
+  "phase": "phase-1",
+  "input_files": ["request.md"],
+  "output_file": "analysis.md",
+  "parallel_task_ids": null
+}
+```
+
+The `prompt` field contains the **4-layer assembled prompt** (see below). When `parallel_task_ids` is non-empty, the orchestrator spawns one agent per task ID concurrently.
+
+#### `checkpoint` — Pause for human review
+
+```json
+{
+  "type": "checkpoint",
+  "name": "checkpoint-a",
+  "present_to_user": "## Design Review\n\n...",
+  "options": ["approve", "reject"]
+}
+```
+
+#### `exec` — Run a shell command
+
+```json
+{
+  "type": "exec",
+  "phase": "pr-creation",
+  "commands": ["gh", "pr", "create", "--title", "feat: ...", "--body", "..."],
+  "setup_only": false
+}
+```
+
+#### `write_file` — Write content to disk
+
+```json
+{
+  "type": "write_file",
+  "phase": "phase-5",
+  "path": ".specs/20260401-fix-auth/tasks.md",
+  "content": "# Tasks\n\n..."
+}
+```
+
+#### `human_gate` — Wait for external human action
+
+```json
+{
+  "type": "human_gate",
+  "phase": "phase-5",
+  "name": "merge-external-pr",
+  "present_to_user": "Task 3 requires merging PR #456 in repo-b...",
+  "options": ["done", "skip", "abandon"]
+}
+```
+
+#### `done` — Pipeline complete
+
+```json
+{
+  "type": "done",
+  "summary": "Pipeline completed: 10 phases, 2 skipped",
+  "summary_path": ".specs/20260401-fix-auth/summary.md"
+}
+```
+
+### 4-Layer Prompt Assembly
+
+The `prompt` field in `spawn_agent` actions is assembled from four layers:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Layer 1: Agent Instructions                         │
+│   (loaded from agents/{name}.md)                    │
+├─────────────────────────────────────────────────────┤
+│ Layer 2: Input/Output Artifacts                     │
+│   ## Input Files                                    │
+│   - {workspace}/request.md                          │
+│   - {workspace}/analysis.md                         │
+│   ## Output File                                    │
+│   - {workspace}/design.md                           │
+├─────────────────────────────────────────────────────┤
+│ Layer 3: Repository Profile                         │
+│   ## Repository Context                             │
+│   Languages: Go (82%), TypeScript (15%)             │
+│   Build command: make build                         │
+│   Test command: go test ./...                       │
+│   Linter: golangci-lint                             │
+├─────────────────────────────────────────────────────┤
+│ Layer 4: Data Flywheel (cross-pipeline learning)    │
+│   ## Similar Past Pipelines                         │
+│   (BM25-scored matches from .specs/index.json)      │
+│   ## Past Review Patterns                           │
+│   (Levenshtein-merged review findings)              │
+│   ## AI Friction Points                             │
+│   (from past improvement.md reports)                │
+└─────────────────────────────────────────────────────┘
+```
+
+Layers 3 and 4 are injected only when data is available. Layer 2 lists file **paths** only — agents read the files themselves.
+
+---
+
+## 4. `pipeline_report_result` — Phase Result Recording
+
+Records metrics, validates artifacts, parses review verdicts, and advances pipeline state.
+
+### Request
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `workspace` | string | yes | Workspace path |
+| `phase` | string | yes | Phase ID (e.g., `"phase-3"`, `"phase-5"`) |
+| `tokens_used` | number | no | Tokens consumed by the phase |
+| `duration_ms` | number | no | Wall-clock duration in ms |
+| `model` | string | no | Model used (e.g., `"sonnet"`, `"opus"`) |
+| `setup_only` | boolean | no | True if exec was setup-only (no agent ran) |
+
+### Response
+
+```json
+{
+  "state_updated": true,
+  "artifact_written": "review-design.md",
+  "verdict_parsed": "APPROVE_WITH_NOTES",
+  "findings": [
+    { "severity": "MINOR", "description": "Consider adding error context to..." }
+  ],
+  "next_action_hint": "proceed",
+  "warning": "",
+  "display_message": ""
+}
+```
+
+### `next_action_hint` Values
+
+| Value | Meaning | Orchestrator Action |
+|-------|---------|-------------------|
+| `proceed` | Phase completed successfully | Continue to next `pipeline_next_action` |
+| `revision_required` | Review verdict is REVISE or FAIL | Present findings to user, re-run phase |
+| `setup_continue` | Internal setup action completed | Engine re-enters `NextAction` automatically |
+
+### Verdict Parsing
+
+The MCP server parses review verdicts from artifact content:
+
+| Phase | Verdicts | Source |
+|-------|----------|--------|
+| phase-3b (Design Review) | `APPROVE`, `APPROVE_WITH_NOTES`, `REVISE` | `review-design.md` |
+| phase-4b (Tasks Review) | `APPROVE`, `APPROVE_WITH_NOTES`, `REVISE` | `review-tasks.md` |
+| phase-6 (Code Review) | `PASS`, `PASS_WITH_NOTES`, `FAIL` | `review-{N}.md` |
+
+---
+
+## Orchestrator Loop — Complete Data Flow
+
+The following shows the exact sequence of MCP tool calls and their payloads for a single phase:
+
+```
+Orchestrator                          MCP Server                     Disk
+    │                                     │                           │
+    │─── pipeline_next_action ───────────►│                           │
+    │    { workspace, previous_* }        │── read state.json ───────►│
+    │                                     │◄── state data ────────────│
+    │                                     │── Engine.NextAction() ────│
+    │                                     │── read agent .md ────────►│
+    │                                     │── 4-layer prompt build ───│
+    │◄── { type: spawn_agent, ... } ──────│                           │
+    │                                     │                           │
+    │─── Agent(prompt=...) ──────────────────────────────────────────►│
+    │                                     │       (agent reads files) │
+    │◄── agent output ───────────────────────────────────────────────│
+    │                                     │                           │
+    │─── Write(analysis.md) ────────────────────────────────────────►│
+    │                                     │                           │
+    │─── pipeline_next_action ───────────►│                           │
+    │    { previous_action_complete: true  │── handleReportResult ────│
+    │      previous_tokens: 15000         │── validate artifact ─────►│
+    │      previous_duration_ms: 45000 }  │── parse verdict ──────────│
+    │                                     │── advance state ─────────►│
+    │◄── { type: spawn_agent, ... } ──────│   (next phase action)     │
+    │         (next phase)                │                           │
+```
+
+> **Key invariant**: The orchestrator never decides which phase to run. It executes the action returned by `pipeline_next_action` and reports the result back. All control flow lives in `Engine.NextAction()`.

--- a/template/sections/ja/architecture/mcp-data-contracts.md
+++ b/template/sections/ja/architecture/mcp-data-contracts.md
@@ -1,0 +1,416 @@
+# MCPデータコントラクト
+
+このドキュメントは、Claudeオーケストレーター（SKILL.md）とGo MCPサーバー（`forge-state-mcp`）間でパイプライン実行中にやりとりされる正確なJSONペイロードを規定します。以下の4つのツールがパイプライン全体のライフサイクルを駆動します。
+
+> **信頼できるソース**: `mcp-server/internal/tools/` および `mcp-server/internal/orchestrator/actions.go` のGo構造体。スキーマ変更時は本ドキュメントとGoコードの両方を更新すること。
+
+---
+
+## 1. `pipeline_init` — 入力解析とレジューム検出
+
+純粋な検出ツール。`/forge` の引数を解析し、ソースタイプを検出し、レジューム候補を確認します。**状態への副作用なし。**
+
+### リクエスト
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `arguments` | string | はい | `/forge` に渡された生の引数文字列 |
+| `current_branch` | string | いいえ | `git branch --show-current` の出力 |
+
+### レスポンス
+
+**レジュームパス**（入力が既存の `.specs/` ディレクトリに一致）:
+
+```json
+{
+  "resume_mode": "auto",
+  "workspace": ".specs/20260330-fix-auth-timeout",
+  "instruction": "call state_resume_info"
+}
+```
+
+**新規パイプラインパス**:
+
+```json
+{
+  "workspace": ".specs/20260401-https-github-com-owner-repo-issues-42",
+  "spec_name": "https-github-com-owner-repo-issues-42",
+  "source_type": "github_issue",
+  "source_url": "https://github.com/owner/repo/issues/42",
+  "source_id": "42",
+  "core_text": "https://github.com/owner/repo/issues/42",
+  "flags": {
+    "auto": false,
+    "skip_pr": false,
+    "debug": false,
+    "discuss": false,
+    "effort_override": null,
+    "current_branch": "main"
+  },
+  "fetch_needed": {
+    "type": "github",
+    "fields": ["labels", "title", "body"],
+    "instruction": "fetch github issue fields before calling pipeline_init_with_context"
+  }
+}
+```
+
+**エラーパス**（無効な入力）:
+
+```json
+{
+  "errors": ["input too short: minimum 3 characters required"]
+}
+```
+
+### `source_type` 値
+
+| 値 | トリガー |
+|-------|---------|
+| `github_issue` | `github.com/.../issues/\d+` に一致するURL |
+| `jira_issue` | `*.atlassian.net/browse/...` に一致するURL |
+| `text` | プレーンテキスト（デフォルト） |
+| `workspace` | 入力に `.specs/` を含む |
+
+---
+
+## 2. `pipeline_init_with_context` — 3回コール確認フロー
+
+複数回コールのハンドシェイクを実装: エフォート検出 → （オプション: ディスカッション） → 確認 & ワークスペース初期化。
+
+### リクエスト
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `workspace` | string | はい | `pipeline_init` からのワークスペースパス |
+| `source_id` | string | いいえ | ソース識別子（例: `"42"`, `"SOA-123"`） |
+| `source_url` | string | いいえ | 元のURL（GitHub/Jira） |
+| `external_context` | object | いいえ | フェッチ済みのGitHub/Jiraフィールド |
+| `flags` | object | いいえ | `pipeline_init` からのパース済みフラグ |
+| `task_text` | string | いいえ | 元のタスクテキスト（テキストソースのみ） |
+| `user_confirmation` | object | いいえ | 確認済みエフォート＋ブランチ決定（2回目コール） |
+| `discussion_answers` | string | いいえ | ディスカッション質問へのユーザー回答 |
+
+**`external_context` オブジェクト:**
+
+```json
+{
+  "github_labels": ["bug", "priority-high"],
+  "github_title": "Fix auth timeout in middleware",
+  "github_body": "requests timeout after 30s",
+  "jira_issue_type": "Bug",
+  "jira_story_points": 3,
+  "jira_summary": "Skip minutes job without integration",
+  "jira_description": "..."
+}
+```
+
+**`user_confirmation` オブジェクト（確認コール）:**
+
+```json
+{
+  "effort": "M",
+  "workspace_slug": "fix-auth-timeout",
+  "use_current_branch": false,
+  "enriched_request_body": "..."
+}
+```
+
+### レスポンス — 1回目コール（エフォート検出）
+
+オーケストレーターがユーザーに提示するための `needs_user_confirmation` を返す:
+
+```json
+{
+  "needs_user_confirmation": {
+    "detected_effort": "M",
+    "effort_options": {
+      "S": {
+        "skipped_phases": [
+          { "phase_id": "phase-2", "label": "Investigation" },
+          { "phase_id": "phase-3b", "label": "Design Review" }
+        ],
+        "recommended": false
+      },
+      "M": {
+        "skipped_phases": [
+          { "phase_id": "phase-4b", "label": "Tasks Review" },
+          { "phase_id": "checkpoint-b", "label": "Human Reviews Tasks" }
+        ],
+        "recommended": true
+      },
+      "L": {
+        "skipped_phases": [],
+        "recommended": false
+      }
+    },
+    "current_branch": "main",
+    "is_main_branch": true,
+    "enriched_request_body": "implement login feature",
+    "message": "Detected effort=\"M\". ..."
+  }
+}
+```
+
+### レスポンス — `--discuss` 付き1回目コール（テキストソースのみ）
+
+```json
+{
+  "needs_discussion": {
+    "questions": [
+      "What is the main goal of this change?",
+      "Are there any constraints or dependencies?",
+      "What is the expected scope of changes?"
+    ],
+    "message": "Please answer the following questions..."
+  }
+}
+```
+
+### レスポンス — 確認コール（ワークスペース確定）
+
+```json
+{
+  "ready": true,
+  "workspace": ".specs/20260401-42-fix-auth-timeout",
+  "effort": "M",
+  "flow_template": "standard",
+  "skipped_phases": ["phase-4b", "checkpoint-b"],
+  "request_md_content": "---\nsource_type: github_issue\n...",
+  "branch": "feature/42-fix-auth-timeout",
+  "create_branch": true
+}
+```
+
+### コール判別
+
+| `discussion_answers` | `user_confirmation` | パス |
+|---|---|---|
+| なし | なし | 1回目コール → エフォート検出 |
+| あり | なし | ディスカッションコール → 本文エンリッチ |
+| なし | あり | 確認コール → ワークスペース初期化 |
+| あり | あり | **エラー** — 曖昧 |
+
+---
+
+## 3. `pipeline_next_action` — アクションディスパッチ
+
+コアループのドライバー。`state.json` を読み、`Engine.NextAction()` を決定論的に実行し、オーケストレーターが実行すべき型付きアクションを返す。
+
+### リクエスト
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `workspace` | string | はい | ワークスペースパス |
+| `previous_action_complete` | boolean | いいえ | agent/exec/write_file完了後にtrue |
+| `previous_tokens` | number | いいえ | 前回アクションのトークン数 |
+| `previous_duration_ms` | number | いいえ | 前回アクションの所要時間（ms） |
+| `previous_model` | string | いいえ | 前回アクションで使用したモデル |
+| `previous_setup_only` | boolean | いいえ | 前回execがsetup-onlyの場合true |
+| `user_response` | string | いいえ | チェックポイントアクションへのユーザー応答 |
+
+### レスポンス構造
+
+すべてのレスポンスは `Action` をオプションのメタデータでラップ:
+
+```json
+{
+  "type": "spawn_agent",
+  "warning": "",
+  "display_message": "Phase 1: Situation Analysis",
+  "report_result": null,
+  ...アクション固有フィールド...
+}
+```
+
+### アクション型
+
+#### `spawn_agent` — LLMサブエージェントのディスパッチ
+
+```json
+{
+  "type": "spawn_agent",
+  "agent": "situation-analyst",
+  "prompt": "...4層組み立てプロンプト...",
+  "model": "sonnet",
+  "phase": "phase-1",
+  "input_files": ["request.md"],
+  "output_file": "analysis.md",
+  "parallel_task_ids": null
+}
+```
+
+`prompt` フィールドは **4層組み立てプロンプト**（後述）を含む。`parallel_task_ids` が空でない場合、オーケストレーターはタスクIDごとに1つのエージェントを並行起動する。
+
+#### `checkpoint` — 人間レビューのための一時停止
+
+```json
+{
+  "type": "checkpoint",
+  "name": "checkpoint-a",
+  "present_to_user": "## Design Review\n\n...",
+  "options": ["approve", "reject"]
+}
+```
+
+#### `exec` — シェルコマンドの実行
+
+```json
+{
+  "type": "exec",
+  "phase": "pr-creation",
+  "commands": ["gh", "pr", "create", "--title", "feat: ...", "--body", "..."],
+  "setup_only": false
+}
+```
+
+#### `write_file` — ディスクへの書き込み
+
+```json
+{
+  "type": "write_file",
+  "phase": "phase-5",
+  "path": ".specs/20260401-fix-auth/tasks.md",
+  "content": "# Tasks\n\n..."
+}
+```
+
+#### `human_gate` — 外部の人間アクションを待機
+
+```json
+{
+  "type": "human_gate",
+  "phase": "phase-5",
+  "name": "merge-external-pr",
+  "present_to_user": "タスク3はrepo-bのPR #456のマージが必要です...",
+  "options": ["done", "skip", "abandon"]
+}
+```
+
+#### `done` — パイプライン完了
+
+```json
+{
+  "type": "done",
+  "summary": "Pipeline completed: 10 phases, 2 skipped",
+  "summary_path": ".specs/20260401-fix-auth/summary.md"
+}
+```
+
+### 4層プロンプト組み立て
+
+`spawn_agent` アクションの `prompt` フィールドは4つの層から組み立てられる:
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 層1: エージェント指示                                 │
+│   （agents/{name}.md からロード）                     │
+├─────────────────────────────────────────────────────┤
+│ 層2: 入出力アーティファクト                           │
+│   ## Input Files                                    │
+│   - {workspace}/request.md                          │
+│   ## Output File                                    │
+│   - {workspace}/design.md                           │
+├─────────────────────────────────────────────────────┤
+│ 層3: リポジトリプロファイル                           │
+│   ## Repository Context                             │
+│   Languages: Go (82%), TypeScript (15%)             │
+│   Build command: make build                         │
+│   Test command: go test ./...                       │
+├─────────────────────────────────────────────────────┤
+│ 層4: データフライホイール（パイプライン横断学習）      │
+│   ## Similar Past Pipelines                         │
+│   （.specs/index.jsonからBM25スコアリング）           │
+│   ## Past Review Patterns                           │
+│   （Levenshtein統合されたレビュー指摘）              │
+│   ## AI Friction Points                             │
+│   （過去のimprovement.mdレポートから）               │
+└─────────────────────────────────────────────────────┘
+```
+
+層3と4はデータが利用可能な場合のみ注入される。層2はファイル**パス**のみをリスト — エージェント自身がファイルを読む。
+
+---
+
+## 4. `pipeline_report_result` — フェーズ結果記録
+
+メトリクス記録、アーティファクト検証、レビュー判定解析、パイプライン状態の前進を行う。
+
+### リクエスト
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `workspace` | string | はい | ワークスペースパス |
+| `phase` | string | はい | フェーズID（例: `"phase-3"`, `"phase-5"`） |
+| `tokens_used` | number | いいえ | フェーズで消費したトークン数 |
+| `duration_ms` | number | いいえ | 実時間の所要時間（ms） |
+| `model` | string | いいえ | 使用モデル（例: `"sonnet"`, `"opus"`） |
+| `setup_only` | boolean | いいえ | execがsetup-onlyの場合true |
+
+### レスポンス
+
+```json
+{
+  "state_updated": true,
+  "artifact_written": "review-design.md",
+  "verdict_parsed": "APPROVE_WITH_NOTES",
+  "findings": [
+    { "severity": "MINOR", "description": "Consider adding error context to..." }
+  ],
+  "next_action_hint": "proceed",
+  "warning": "",
+  "display_message": ""
+}
+```
+
+### `next_action_hint` 値
+
+| 値 | 意味 | オーケストレーターのアクション |
+|-------|---------|-------------------|
+| `proceed` | フェーズ正常完了 | 次の `pipeline_next_action` へ |
+| `revision_required` | レビュー判定がREVISEまたはFAIL | ユーザーにフィンディングを提示、フェーズ再実行 |
+| `setup_continue` | 内部セットアップアクション完了 | エンジンが自動的に `NextAction` に再入 |
+
+### 判定解析
+
+MCPサーバーはアーティファクト内容からレビュー判定を解析:
+
+| フェーズ | 判定 | ソース |
+|-------|----------|--------|
+| phase-3b（設計レビュー） | `APPROVE`, `APPROVE_WITH_NOTES`, `REVISE` | `review-design.md` |
+| phase-4b（タスクレビュー） | `APPROVE`, `APPROVE_WITH_NOTES`, `REVISE` | `review-tasks.md` |
+| phase-6（コードレビュー） | `PASS`, `PASS_WITH_NOTES`, `FAIL` | `review-{N}.md` |
+
+---
+
+## オーケストレーターループ — 完全なデータフロー
+
+単一フェーズに対するMCPツールコールとペイロードの正確なシーケンス:
+
+```
+オーケストレーター                     MCPサーバー                      ディスク
+    │                                     │                           │
+    │─── pipeline_next_action ───────────►│                           │
+    │    { workspace, previous_* }        │── state.json読込 ─────────►│
+    │                                     │◄── 状態データ ─────────────│
+    │                                     │── Engine.NextAction() ────│
+    │                                     │── agent .md読込 ──────────►│
+    │                                     │── 4層プロンプト構築 ───────│
+    │◄── { type: spawn_agent, ... } ──────│                           │
+    │                                     │                           │
+    │─── Agent(prompt=...) ──────────────────────────────────────────►│
+    │                                     │       (エージェント読込)   │
+    │◄── エージェント出力 ───────────────────────────────────────────│
+    │                                     │                           │
+    │─── Write(analysis.md) ────────────────────────────────────────►│
+    │                                     │                           │
+    │─── pipeline_next_action ───────────►│                           │
+    │    { previous_action_complete: true  │── handleReportResult ────│
+    │      previous_tokens: 15000         │── アーティファクト検証 ────►│
+    │      previous_duration_ms: 45000 }  │── 判定解析 ────────────────│
+    │                                     │── 状態前進 ───────────────►│
+    │◄── { type: spawn_agent, ... } ──────│   (次フェーズアクション)   │
+    │         (次フェーズ)                │                           │
+```
+
+> **重要な不変条件**: オーケストレーターはどのフェーズを実行するか決定しない。`pipeline_next_action` が返すアクションを実行し、結果を報告するのみ。すべての制御フローは `Engine.NextAction()` に存在する。


### PR DESCRIPTION
## Summary

- **Source ID in branch/PR title**: When a GitHub issue URL or Jira URL is passed to `/forge`, the issue number (e.g., `42`) or Jira key (e.g., `SOA-2883`) is now prepended to the branch name and PR title automatically. Previously, the LLM-generated slug overwrote the source ID set by `refineWorkspacePath`.
- **Deterministic effort recommendation**: Added `recommended` boolean flag to each `EffortOption` in the `effort_options` response. The orchestrator now reads the `recommended` field from the MCP response instead of independently deciding which option to mark — eliminating the bug where `S` was always shown as "(Recommended)" regardless of the detected effort.
- **PR body Summary section**: The PR body was previously filled entirely with the Verification Report. Added a `## Summary` section at the top of `summary.md` derived from `request.md` and `design.md`, giving PR reviewers a concise description of what was implemented. `request.md` is now passed as input to the final-summary phase.
- **MCP Data Contracts documentation**: New architecture document (EN + JA) specifying the exact JSON request/response schemas for the 4 core pipeline MCP tools (`pipeline_init`, `pipeline_init_with_context`, `pipeline_next_action`, `pipeline_report_result`), including 4-layer prompt assembly and orchestrator loop data flow. Added via docs-ssot with VitePress sidebar entries.
- **Go doc support**: Added canonical `doc.go` files for all 12 internal packages plus `cmd`, describing each package's purpose, key types, and import direction. Separated per-file header comments from `package` declarations so `go doc` displays only the canonical documentation. Fixed stale MCP tool count (45 → 44).

## Test plan

- [x] `go test ./...` — all 13 packages pass
- [x] `TestSourceIDPrependedToWorkspaceSlug` — 3 cases (GitHub, Jira, text) verify source_id is prepended to LLM slug
- [x] `TestPipelineInitWithContextFirstCallEffortOptions` — verifies `recommended` flag matches `detected_effort` for all 3 effort levels
- [x] `make docs-validate` — all template includes resolve
- [x] `go doc ./internal/orchestrator` — shows only doc.go content (no duplicate per-file comments)

Generated with [Claude Code](https://claude.com/claude-code)