### PR TITLE
fix(dashboard): share event log across sessions for single-port multi-project view

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -19,6 +19,7 @@ Ordered by priority. Higher rows should be tackled first.
 | 6 | **F19** | [#18](https://github.com/hiromaily/claude-forge/issues/18) | CI feedback loop (post-PR auto-fix) | Feature | L | After PR creation, monitor CI results and auto-trigger fix flow on failure. Closes the quality loop beyond the pipeline boundary. |
 | 7 | **F6** | [#19](https://github.com/hiromaily/claude-forge/issues/19) | Adaptive model routing | Feature | L | Needs phase-stats data before deciding. Could now be informed by the accumulated `analytics_*` metrics. |
 | 8 | **F2** | [#20](https://github.com/hiromaily/claude-forge/issues/20) | Execution log (JSONL) | Feature | M | Basic coverage via phase-log. Full JSONL log deferred until the need is confirmed. |
+| 9 | **F20** | — | Shared events log rotation / pruning | Maintenance | S | `~/.claude/forge-events.jsonl` is append-only and grows indefinitely. `SetEventLog` loads the entire file into memory on startup. After weeks of use across many projects the file and in-memory `history` slice will become large. Add max-age trimming (e.g. keep last 30 days) or a file-size cap with rollover to `forge-events.jsonl.old`. |
 
 **Effort key:** XS = < 30min, S = 1-2h, M = half day, L = 1+ day
 

--- a/mcp-server/cmd/main.go
+++ b/mcp-server/cmd/main.go
@@ -73,16 +73,6 @@ func resolveAgentDir() string {
 }
 
 // resolveEventsLog returns the path for the shared JSONL event log.
-//
-// Priority:
-//  1. FORGE_EVENTS_LOG environment variable (explicit override)
-//  2. ~/.claude/forge-events.jsonl (default — shared across all project sessions)
-//
-// Using a home-directory path instead of a per-project specsDir path ensures
-// that all MCP server instances (one per Claude Code session, regardless of
-// project) write to the same file. The instance that owns the dashboard port
-// can then tail this file to show events from every active session.
-// resolveEventsLog returns the path for the shared JSONL event log.
 // It is a pure function: it reads env vars and the OS home directory but
 // performs no filesystem operations (caller is responsible for MkdirAll).
 //

--- a/mcp-server/cmd/main.go
+++ b/mcp-server/cmd/main.go
@@ -72,21 +72,68 @@ func resolveAgentDir() string {
 	return "agents"
 }
 
+// resolveEventsLog returns the path for the shared JSONL event log.
+//
+// Priority:
+//  1. FORGE_EVENTS_LOG environment variable (explicit override)
+//  2. ~/.claude/forge-events.jsonl (default — shared across all project sessions)
+//
+// Using a home-directory path instead of a per-project specsDir path ensures
+// that all MCP server instances (one per Claude Code session, regardless of
+// project) write to the same file. The instance that owns the dashboard port
+// can then tail this file to show events from every active session.
+// resolveEventsLog returns the path for the shared JSONL event log.
+// It is a pure function: it reads env vars and the OS home directory but
+// performs no filesystem operations (caller is responsible for MkdirAll).
+//
+// Priority:
+//  1. FORGE_EVENTS_LOG environment variable (explicit override)
+//  2. ~/.claude/forge-events.jsonl (default — shared across all project sessions)
+//
+// Using a home-directory path instead of a per-project specsDir path ensures
+// that all MCP server instances (one per Claude Code session, regardless of
+// project) write to the same file. The instance that owns the dashboard port
+// can then tail this file to show events from every active session.
+//
+// Note: deployments that have per-project events.jsonl files from versions prior
+// to this change will find those files orphaned under .specs/. They are no longer
+// read or written; historical events from prior runs will not appear on the dashboard.
+func resolveEventsLog() string {
+	if p := os.Getenv("FORGE_EVENTS_LOG"); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "forge-events.jsonl"
+	}
+	return filepath.Join(home, ".claude", "forge-events.jsonl")
+}
+
 func main() {
 	sm := state.NewStateManager(appVersion)
 	specsDir := resolveSpecsDir()
 	sm.SetSpecsDir(specsDir)
 	srv := server.NewMCPServer("forge-state", appVersion)
 	bus := events.NewEventBus()
-	// Enable JSONL-based event persistence so dashboard reloads and new sessions
-	// can replay historical events. All MCP server instances sharing the same
-	// specsDir will read/write the same log file.
-	eventLogPath := filepath.Join(specsDir, "events.jsonl")
+	// Enable JSONL-based event persistence with a shared log path so all MCP server
+	// instances (across different project sessions) write to the same file.
+	// The instance that owns the dashboard port tails this file via WatchEventLog
+	// to show events from every active session on a single dashboard.
+	eventLogPath := resolveEventsLog()
+	_ = os.MkdirAll(filepath.Dir(eventLogPath), 0o700)
 	if err := bus.SetEventLog(eventLogPath); err != nil {
 		fmt.Fprintf(os.Stderr, "forge-state: event log setup warning: %v\n", err)
 	}
-	slack := events.NewSlackNotifier(os.Getenv("FORGE_SLACK_WEBHOOK_URL"))
 	eventsPort := os.Getenv("FORGE_EVENTS_PORT")
+	// Start tailing the shared event log only on the instance that serves the dashboard.
+	// Other instances write to the shared file but do not need to read it back.
+	// This keeps pipeline and dashboard concerns separated: non-dashboard instances
+	// perform no dashboard-related I/O beyond the log write in Publish.
+	watchCtx, cancelWatch := context.WithCancel(context.Background())
+	if eventsPort != "" {
+		bus.WatchEventLog(watchCtx)
+	}
+	slack := events.NewSlackNotifier(os.Getenv("FORGE_SLACK_WEBHOOK_URL"))
 	agentDir := resolveAgentDir()
 	eng := orchestrator.NewEngine(agentDir, specsDir)
 	histIdx := history.New(specsDir)
@@ -118,7 +165,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// Graceful shutdown of the HTTP server after ServeStdio returns.
+	// Stop the WatchEventLog goroutine and perform graceful HTTP shutdown.
+	cancelWatch()
 	if httpSrv != nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/mcp-server/internal/events/bus.go
+++ b/mcp-server/internal/events/bus.go
@@ -5,12 +5,14 @@ package events
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // Event represents a pipeline lifecycle notification.
@@ -35,6 +37,10 @@ const subscriberBufferSize = 64
 //
 // When a log file path is configured via SetEventLog, events are persisted to a JSONL file
 // so that dashboard reloads and new sessions can replay historical events.
+//
+// WatchEventLog enables multi-process event sharing: events written to the shared log by
+// other MCP server instances (e.g. sessions from other projects) are tailed and broadcast
+// to live SSE subscribers, so a single dashboard port shows all active pipelines.
 type EventBus struct {
 	mu          sync.RWMutex
 	subscribers map[string]chan Event
@@ -42,19 +48,34 @@ type EventBus struct {
 
 	// history stores all events seen during this process lifetime plus any
 	// loaded from the JSONL log file on startup.
+	// histMap is a dedup index keyed by histKey(e) for O(1) lookup in addAndBroadcast.
+	// Both are protected by histMu.
 	histMu  sync.RWMutex
 	history []Event
+	histMap map[string]struct{}
 
 	// logFile is the append-only JSONL event log. nil when persistence is disabled.
-	logMu   sync.Mutex
-	logFile *os.File
+	// logPath and tailOffset are set once by SetEventLog before any concurrent access.
+	logMu      sync.Mutex
+	logFile    *os.File
+	logPath    string
+	tailOffset atomic.Int64
 }
 
 // NewEventBus constructs a new, empty EventBus.
 func NewEventBus() *EventBus {
 	return &EventBus{
 		subscribers: make(map[string]chan Event),
+		histMap:     make(map[string]struct{}),
 	}
+}
+
+// histKey returns a string that uniquely identifies an event for deduplication.
+// It uses the fields most likely to distinguish separate events: timestamp, workspace,
+// event type, phase, and outcome. The Detail field is included to handle edge cases
+// such as two agent-dispatch events for the same phase (parallel tasks).
+func histKey(e Event) string {
+	return e.Timestamp + "|" + e.Workspace + "|" + e.Event + "|" + e.Phase + "|" + e.Outcome + "|" + e.Detail
 }
 
 // SetEventLog configures JSONL-based event persistence. It loads any existing
@@ -79,8 +100,17 @@ func (b *EventBus) SetEventLog(path string) error {
 	if len(loaded) > 0 {
 		b.histMu.Lock()
 		b.history = append(loaded, b.history...)
+		for _, e := range loaded {
+			b.histMap[histKey(e)] = struct{}{}
+		}
 		b.histMu.Unlock()
 		fmt.Fprintf(os.Stderr, "forge-state: loaded %d historical events from %s\n", len(loaded), path)
+	}
+
+	// Record file size after loading so WatchEventLog starts tailing from here.
+	// Events before this offset are already in history; we only broadcast new appends.
+	if fi, statErr := os.Stat(path); statErr == nil {
+		b.tailOffset.Store(fi.Size())
 	}
 
 	// Open (or create) the file in append mode for future writes.
@@ -90,8 +120,102 @@ func (b *EventBus) SetEventLog(path string) error {
 	}
 	b.logMu.Lock()
 	b.logFile = f
+	b.logPath = path
 	b.logMu.Unlock()
 	return nil
+}
+
+// WatchEventLog starts a background goroutine that tails the shared event log file
+// and broadcasts new events written by other MCP server processes to live SSE subscribers.
+// This enables a single dashboard to show events from all active project sessions.
+// Events already in history (written by this instance) are deduplicated and skipped.
+// The goroutine exits when ctx is cancelled.
+func (b *EventBus) WatchEventLog(ctx context.Context) {
+	b.logMu.Lock()
+	path := b.logPath
+	b.logMu.Unlock()
+	if path == "" {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		offset := b.tailOffset.Load()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				offset = b.readTail(path, offset)
+			}
+		}
+	}()
+}
+
+// readTail reads new events appended to path since offset, calls addAndBroadcast for each,
+// and returns the new file offset to resume from next time.
+func (b *EventBus) readTail(path string, offset int64) int64 {
+	// Stat before opening: skip the open syscall entirely when nothing is new.
+	fi, err := os.Stat(path)
+	if err != nil || fi.Size() <= offset {
+		return offset
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return offset
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return offset
+	}
+
+	reader := bufio.NewReader(f)
+	for {
+		line, readErr := reader.ReadBytes('\n')
+		line = bytes.TrimRight(line, "\r\n")
+		if len(line) > 0 {
+			var e Event
+			if jsonErr := json.Unmarshal(line, &e); jsonErr == nil {
+				b.addAndBroadcast(e)
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			break
+		}
+	}
+
+	// Use the file size at the start of this read as the new offset.
+	// Any bytes appended during the read will be re-processed next tick;
+	// addAndBroadcast deduplicates against history so re-processing is safe.
+	return fi.Size()
+}
+
+// addAndBroadcast adds e to history if not already present and broadcasts it to live
+// subscribers. It does NOT write to the log file (the event is already there —
+// this is called by readTail for events written by other MCP server processes).
+func (b *EventBus) addAndBroadcast(e Event) {
+	b.histMu.Lock()
+	if _, ok := b.histMap[histKey(e)]; ok {
+		b.histMu.Unlock()
+		return // already in history — our own event or a cross-process duplicate
+	}
+	b.history = append(b.history, e)
+	b.histMap[histKey(e)] = struct{}{}
+	b.histMu.Unlock()
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for _, ch := range b.subscribers {
+		select {
+		case ch <- e:
+		default:
+		}
+	}
 }
 
 // History returns a copy of all historical events (loaded from file + current session).
@@ -136,9 +260,10 @@ func (b *EventBus) Unsubscribe(id string) {
 // Publish acquires only a read lock so concurrent Publish calls do not serialize.
 // The event is also appended to the in-memory history and JSONL log file.
 func (b *EventBus) Publish(e Event) {
-	// Append to in-memory history.
+	// Append to in-memory history and dedup index.
 	b.histMu.Lock()
 	b.history = append(b.history, e)
+	b.histMap[histKey(e)] = struct{}{}
 	b.histMu.Unlock()
 
 	// Persist to JSONL log file (best-effort).

--- a/mcp-server/internal/events/bus.go
+++ b/mcp-server/internal/events/bus.go
@@ -154,10 +154,25 @@ func (b *EventBus) WatchEventLog(ctx context.Context) {
 
 // readTail reads new events appended to path since offset, calls addAndBroadcast for each,
 // and returns the new file offset to resume from next time.
+//
+// Only complete lines (terminated by '\n') are processed; a partial line at EOF
+// (another process mid-write) is left for the next tick. The returned offset
+// reflects bytes actually consumed, not fi.Size(), so a transient I/O error
+// does not cause the unread portion to be silently skipped.
+//
+// Truncation: if fi.Size() < offset the file was rotated or manually truncated;
+// the offset is reset to 0 so reading resumes from the beginning.
 func (b *EventBus) readTail(path string, offset int64) int64 {
 	// Stat before opening: skip the open syscall entirely when nothing is new.
 	fi, err := os.Stat(path)
-	if err != nil || fi.Size() <= offset {
+	if err != nil {
+		return offset
+	}
+	// Handle file truncation / rotation: reset to start.
+	if fi.Size() < offset {
+		offset = 0
+	}
+	if fi.Size() <= offset {
 		return offset
 	}
 
@@ -173,26 +188,27 @@ func (b *EventBus) readTail(path string, offset int64) int64 {
 
 	reader := bufio.NewReader(f)
 	for {
-		line, readErr := reader.ReadBytes('\n')
-		line = bytes.TrimRight(line, "\r\n")
-		if len(line) > 0 {
-			var e Event
-			if jsonErr := json.Unmarshal(line, &e); jsonErr == nil {
-				b.addAndBroadcast(e)
+		raw, readErr := reader.ReadBytes('\n')
+		if len(raw) > 0 {
+			if raw[len(raw)-1] == '\n' {
+				// Complete line: parse, broadcast, and advance the offset.
+				line := bytes.TrimRight(raw, "\r\n")
+				var e Event
+				if jsonErr := json.Unmarshal(line, &e); jsonErr == nil {
+					b.addAndBroadcast(e)
+				}
+				offset += int64(len(raw))
+			} else {
+				// Partial line at EOF (writer mid-write): stop here; next tick will retry.
+				break
 			}
-		}
-		if readErr == io.EOF {
-			break
 		}
 		if readErr != nil {
 			break
 		}
 	}
 
-	// Use the file size at the start of this read as the new offset.
-	// Any bytes appended during the read will be re-processed next tick;
-	// addAndBroadcast deduplicates against history so re-processing is safe.
-	return fi.Size()
+	return offset
 }
 
 // addAndBroadcast adds e to history if not already present and broadcasts it to live

--- a/mcp-server/internal/events/bus_test.go
+++ b/mcp-server/internal/events/bus_test.go
@@ -426,6 +426,69 @@ func TestWatchEventLog_SkipsOwnEvents(t *testing.T) {
 	}
 }
 
+// TestWatchEventLog_TruncationResetsOffset verifies that if the shared log file is
+// truncated (e.g. rotated), WatchEventLog resets its offset to zero and resumes
+// reading from the beginning of the new file content.
+func TestWatchEventLog_TruncationResetsOffset(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.jsonl")
+
+	bus := events.NewEventBus()
+	if err := bus.SetEventLog(logPath); err != nil {
+		t.Fatalf("SetEventLog: %v", err)
+	}
+	t.Cleanup(func() { bus.CloseLog() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	bus.WatchEventLog(ctx)
+
+	// Subscribe before any writes so the channel captures all broadcasts.
+	_, ch := bus.Subscribe()
+
+	// Write a large first event (Detail field makes it noticeably longer than second).
+	// This ensures the second file, written after truncation, is strictly smaller,
+	// triggering the fi.Size() < offset truncation-reset path in readTail.
+	first := events.Event{
+		Event: "phase-start", Phase: "phase-1", SpecName: "proj",
+		Workspace: "/proj/.specs/ws", Timestamp: "2026-04-18T12:00:00Z",
+		Outcome: "in_progress", Detail: "this-detail-makes-the-line-longer-than-the-second-event",
+	}
+	line, _ := json.Marshal(first)
+	if err := os.WriteFile(logPath, append(line, '\n'), 0o600); err != nil {
+		t.Fatalf("write first event: %v", err)
+	}
+
+	// Wait for the first tick to process the initial event so tailOffset advances.
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for first event")
+	}
+
+	// Simulate file truncation: overwrite with a shorter event.
+	// fi.Size() of the new file is less than the current tailOffset,
+	// which triggers the reset-to-zero path in readTail.
+	second := events.Event{
+		Event: "phase-start", Phase: "phase-2", SpecName: "proj",
+		Workspace: "/proj/.specs/ws", Timestamp: "2026-04-18T12:01:00Z", Outcome: "in_progress",
+	}
+	line2, _ := json.Marshal(second)
+	if err := os.WriteFile(logPath, append(line2, '\n'), 0o600); err != nil {
+		t.Fatalf("write truncated event: %v", err)
+	}
+
+	select {
+	case got := <-ch:
+		if got != second {
+			t.Errorf("received event = %+v, want %+v", got, second)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out: event after truncation was not broadcast")
+	}
+}
+
 // TestCloseLogIdempotent verifies that CloseLog can be called multiple times without panic.
 func TestCloseLogIdempotent(t *testing.T) {
 	t.Parallel()

--- a/mcp-server/internal/events/bus_test.go
+++ b/mcp-server/internal/events/bus_test.go
@@ -1,6 +1,7 @@
 package events_test
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -313,6 +314,115 @@ func TestLoadMalformedJSONLSkipsBadLines(t *testing.T) {
 	}
 	if !reflect.DeepEqual(hist[0], good) {
 		t.Errorf("History()[0] = %+v, want %+v", hist[0], good)
+	}
+}
+
+// TestWatchEventLog_PicksUpCrossProcessEvents verifies that events appended to the shared
+// log file by another process (simulated by a direct file write) are picked up by
+// WatchEventLog and broadcast to live SSE subscribers within a few seconds.
+func TestWatchEventLog_PicksUpCrossProcessEvents(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.jsonl")
+
+	bus := events.NewEventBus()
+	if err := bus.SetEventLog(logPath); err != nil {
+		t.Fatalf("SetEventLog: %v", err)
+	}
+	t.Cleanup(func() { bus.CloseLog() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	bus.WatchEventLog(ctx)
+
+	// Subscribe before the external write so we receive the live broadcast.
+	_, ch := bus.Subscribe()
+
+	// Simulate another MCP server instance appending an event to the shared log.
+	external := events.Event{
+		Event:     "phase-start",
+		Phase:     "phase-1",
+		SpecName:  "other-project",
+		Workspace: "/other/project/.specs/ws",
+		Timestamp: "2026-04-18T10:00:00Z",
+		Outcome:   "in_progress",
+	}
+	line, _ := json.Marshal(external)
+	f, err := os.OpenFile(logPath, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open log for external write: %v", err)
+	}
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		t.Fatalf("external write: %v", err)
+	}
+	_ = f.Close()
+
+	// WatchEventLog polls every second; allow up to 3 seconds for pickup.
+	select {
+	case got := <-ch:
+		if got != external {
+			t.Errorf("received event = %+v, want %+v", got, external)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out: cross-process event not broadcast within 3 seconds")
+	}
+
+	// The event must also appear in History so dashboard reloads show it.
+	hist := bus.History()
+	if !reflect.DeepEqual(hist[len(hist)-1], external) {
+		t.Errorf("History does not contain cross-process event; last = %+v", hist[len(hist)-1])
+	}
+}
+
+// TestWatchEventLog_NoopWhenLogPathEmpty verifies that WatchEventLog does not panic
+// or start a goroutine when no log path is configured.
+func TestWatchEventLog_NoopWhenLogPathEmpty(t *testing.T) {
+	t.Parallel()
+	bus := events.NewEventBus()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()               // cancelled immediately
+	bus.WatchEventLog(ctx) // must not panic
+}
+
+// TestWatchEventLog_SkipsOwnEvents verifies that events published by this instance
+// (already in history) are NOT re-broadcast when the tail picks them up from the file.
+func TestWatchEventLog_SkipsOwnEvents(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.jsonl")
+
+	bus := events.NewEventBus()
+	if err := bus.SetEventLog(logPath); err != nil {
+		t.Fatalf("SetEventLog: %v", err)
+	}
+	t.Cleanup(func() { bus.CloseLog() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	bus.WatchEventLog(ctx)
+
+	own := events.Event{
+		Event:     "phase-complete",
+		Phase:     "phase-3",
+		SpecName:  "this-project",
+		Workspace: "/this/.specs/ws",
+		Timestamp: "2026-04-18T11:00:00Z",
+		Outcome:   "completed",
+	}
+	bus.Publish(own) // written to file + history by this instance
+
+	// Subscribe after Publish so the channel starts empty.
+	_, ch := bus.Subscribe()
+
+	// Wait long enough for at least one tail poll (1 second + buffer).
+	time.Sleep(1500 * time.Millisecond)
+
+	// Channel must be empty: our own event must not be re-broadcast.
+	select {
+	case got := <-ch:
+		t.Errorf("unexpected re-broadcast of own event: %+v", got)
+	default:
+		// correct — nothing re-broadcast
 	}
 }
 


### PR DESCRIPTION
## Problem

When multiple Claude Code sessions are open simultaneously (e.g. one for `claude-forge`, another for `japan-immigration-map`), each MCP server instance owns its own in-memory event bus. Whichever instance grabs port 8099 first ends up serving a dashboard with no events, because it is a different process from the one running the active pipeline. Users have no way to see all active pipeline sessions in one place.

## Solution

All MCP instances now share a single append-only event log at `~/.claude/forge-events.jsonl` (overridable via `FORGE_EVENTS_LOG`). The instance that owns the dashboard port tails this file every second and broadcasts new events written by other instances to live SSE subscribers. A single `http://localhost:8099/` now shows pipeline events from **every** active project session simultaneously.

## Changes

### `mcp-server/internal/events/bus.go`

- **`WatchEventLog(ctx)`** — new method: polls the shared log file every second, reads new lines appended by other processes, and broadcasts them to live SSE subscribers via `addAndBroadcast`.
- **`addAndBroadcast`** — adds cross-process events to history and fans out to subscribers. Uses an O(1) `histMap` (keyed on `Timestamp|Workspace|Event|Phase|Outcome|Detail`) instead of an O(n) `slices.Contains` scan to deduplicate own-process events.
- **`histMap`** — kept in sync by both `Publish()` and `SetEventLog()` (for loaded historical events), so own-process events are never re-broadcast.
- **`readTail`** — `os.Stat` check before `os.Open` avoids unnecessary syscalls when nothing new has been appended.

### `mcp-server/cmd/main.go`

- **`resolveEventsLog()`** — pure resolver: `FORGE_EVENTS_LOG` env > `~/.claude/forge-events.jsonl`; `MkdirAll` is called by the caller (`main`) rather than inside the resolver.
- **Pipeline/dashboard separation** — `WatchEventLog` is only started when `FORGE_EVENTS_PORT` is set. Non-dashboard instances write to the shared log but perform no polling I/O, keeping pipeline and dashboard concerns decoupled.

### `BACKLOG.md`

- Added **F20**: `~/.claude/forge-events.jsonl` is append-only and unbounded; rotation/pruning needed for long-running installs.

## Behaviour Change

| Before | After |
|--------|-------|
| Each session's dashboard shows only its own events | All sessions share one dashboard at port 8099 |
| Per-project `.specs/events.jsonl` | Shared `~/.claude/forge-events.jsonl` |
| Non-dashboard instances: no-op | Non-dashboard instances: write-only (no polling) |

> **Migration note**: Per-project `.specs/events.jsonl` files from prior versions are orphaned by this change. Historical events from those files will not appear on the new shared dashboard.

## Test Plan

- [x] `TestWatchEventLog_PicksUpCrossProcessEvents` — simulates a foreign-process write; verifies live broadcast and history inclusion within 3 s
- [x] `TestWatchEventLog_SkipsOwnEvents` — verifies own-process events are not re-broadcast after the tail picks them up from the file
- [x] `TestWatchEventLog_NoopWhenLogPathEmpty` — verifies no panic when no log is configured
- [x] All 14 packages pass `go test -race ./...`
- [x] `go tool golangci-lint run --fix` — zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)