### PR TITLE
docs(research): remote dashboard control

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -170,6 +170,10 @@ export default withMermaid(
                     text: "Codex Integration",
                     link: "/research/codex-integration",
                   },
+                  {
+                    text: "Remote Dashboard Control",
+                    link: "/research/remote-dashboard-control",
+                  },
                 ],
               },
             ],
@@ -344,6 +348,10 @@ export default withMermaid(
                   {
                     text: "Codex 統合可否調査",
                     link: "/ja/research/codex-integration",
+                  },
+                  {
+                    text: "ダッシュボードのリモートコントロール",
+                    link: "/ja/research/remote-dashboard-control",
                   },
                 ],
               },

--- a/docs/ja/research/remote-dashboard-control.md
+++ b/docs/ja/research/remote-dashboard-control.md
@@ -1,0 +1,252 @@
+# ダッシュボードのリモートコントロール
+
+Status: draft v1 (2026-04-18)
+
+## 概要
+
+このドキュメントでは、forge ダッシュボードを外部デバイス（スマートフォン、タブレット、リモートマシン）
+からアクセス可能にし、チェックポイントの承認が Claude パイプラインを自動的に再開できるようにするための
+アーキテクチャについて説明します。ターミナルへの入力は不要です。
+
+## 問題の概要
+
+### 現在のフロー
+
+```text
+Claude（ターミナル）         ダッシュボード（ブラウザ）      state.json
+       │                          │                         │
+       │── pipeline_next_action ──▶ エンジン: checkpoint    │
+       │                          │                         │
+       │── checkpoint() ──────────────────────────────────▶ │ status=awaiting_human
+       │                          │                         │
+       │  [AskUserQuestion]       │── approve ボタン ──────▶│ PhaseComplete()
+       │  ターミナル入力待ち       │                         │ status=pending（次フェーズ）
+       │  でブロック中             │   "approved" ✓          │
+       │                          │                         │
+       │  [何も起こらない]         │                         │
+       │  まだブロック中           │                         │
+```
+
+ユーザーがダッシュボードの "approve" をクリックすると、`sm.PhaseComplete()` が
+`state.json` を次のフェーズに進めます。しかし Claude は `AskUserQuestion` でターミナル
+入力を待ったままブロックされています。承認はステートに書き込まれますが、Claude は
+目覚めません。
+
+また、ダッシュボードサーバーは `127.0.0.1` にのみバインドされているため、外部デバイスから
+のアクセスは変更なしでは不可能です。
+
+### 目標
+
+1. ダッシュボードの承認でパイプラインが自動再開される — ターミナル操作は不要。
+2. ngrok 経由でダッシュボードを外部デバイス（スマートフォン、リモートマシン）からアクセス可能にする。
+3. マルチパイプライン監視とタスク投入（フェーズ2）の基盤を構築する。
+
+---
+
+## フェーズ1: EventBus ロングポール + リモートアクセス
+
+### コアメカニズム: `pipeline_next_action` における EventBus ロングポール
+
+SKILL.md がチェックポイントで `AskUserQuestion` をブロックする代わりに、MCP ツール
+自体がステートの変化を待機します。`pipeline_next_action` が `currentPhaseStatus ==
+"awaiting_human"` かつ `user_response` なしで呼ばれた場合:
+
+1. ハンドラーはプロセス内の `EventBus` を購読します。
+2. 現在のチェックポイントフェーズの `phase-complete` イベントを最大 **N 秒**（例: 15 秒
+   — MCP ツールコールタイムアウト内で安全）待機します。
+3. **イベントが届いた場合**（ダッシュボードが `PhaseComplete` を呼出し → EventBus が発行）:
+   ステートを再読込 → `eng.NextAction` → `sm.PhaseStart` → 次の実際のアクション
+   （例: フェーズ4の `spawn_agent`）を返す。Claude はターミナル操作なしで続行します。
+4. **タイムアウト**（イベントなし）: `{type: "checkpoint", still_waiting: true}` と同じ
+   チェックポイント表示テキストを返します。
+
+```text
+Claude（AskUserQuestion なし）     MCP サーバー                ダッシュボード
+       │                                │                           │
+       │── pipeline_next_action() ─────▶│                           │
+       │                                │ EventBus を購読           │
+       │   [MCP コール ブロック中]      │ 最大15秒待機              │
+       │                                │                           │
+       │                                │◀── PhaseComplete() ───────│ ユーザーが承認クリック
+       │                                │ イベント: phase-complete   │
+       │                                │ ステート再読込            │
+       │                                │ eng.NextAction            │
+       │◀─ {type: "spawn_agent"} ───────│ PhaseStart               │
+       │                                │                           │
+       │  パイプライン続行              │                           │
+```
+
+15 秒以内にダッシュボードの承認がなければ、ツールは `still_waiting: true` を返します。
+SKILL.md は即座に `pipeline_next_action` を再度呼びます（スリープなし、ターミナルプロンプト
+なし）。15 秒のサーバーサイド遅延が自然なペーシングを提供します。
+
+### ターミナルユーザーのパス
+
+最大 15 秒の遅延はありますが、ターミナルの正確性は影響を受けません:
+
+1. Claude は `pipeline_next_action` ロングポールでブロックされています。
+2. ユーザーがターミナルで "proceed" と入力 → Claude Code はメッセージをキューに追加。
+3. 15 秒後（またはダッシュボードが先に承認した場合）、ツールは `still_waiting: true` を返します。
+4. Claude はキューの "proceed" を処理 → `pipeline_next_action(user_response="proceed")` を呼出し。
+5. P8 ブロックが `sm.PhaseComplete` を呼び、エンジンが次のアクションを返します。
+
+### SKILL.md の変更（最小限）
+
+変更はチェックポイントアクションのハンドラーのみです:
+
+```text
+- `checkpoint`: checkpoint() を呼出し。action.present_to_user + ダッシュボード URL を出力。
+  次に即座に pipeline_next_action() を呼出す（user_response なし、AskUserQuestion なし）。
+  - still_waiting: true  → 即座に pipeline_next_action() を再呼出し。
+  - チェックポイント以外のアクションが返った → ダッシュボードが承認済み; 通常通り続行。
+  - ユーザーはいつでもターミナルで入力可能; メッセージは現在の pipeline_next_action()
+    呼出しが返った後（最大15秒）に処理される。
+```
+
+### 変更サマリー
+
+| コンポーネント | 変更内容 | 規模 |
+| --- | --- | --- |
+| `pipeline_next_action.go` | `awaiting_human` + `user_response` なし時のロングポール追加 | 中 |
+| `SKILL.md` | `AskUserQuestion` を `still_waiting` での即時再呼出しに置き換え | 小 |
+| `dashboard.html` | 承認後: "Pipeline will continue automatically" を表示 | 小 |
+| `intervention.go` | オプション: ベアラートークン認証（`FORGE_DASHBOARD_TOKEN`） | 小 |
+
+### ngrok 経由のリモートアクセス
+
+サーバーのバインドアドレス変更は不要です。ダッシュボードは `127.0.0.1` のままです。
+ngrok が外部トラフィックをローカルポートに転送します:
+
+```text
+スマートフォンブラウザ
+       │
+       ▼ HTTPS
+  ngrok トンネル（例: https://abc123.ngrok.io）
+       │
+       ▼ HTTP（ループバック）
+  127.0.0.1:8099  ←  forge ダッシュボードサーバー
+```
+
+`intervention.go` の `isLocalRequest` ガードは ngrok エージェントのループバック
+接続のみを見るため、変更なしで通過します。
+
+ブラウザからの `Origin` ヘッダーは ngrok の URL になるため、現在のオリジンチェックは
+失敗します。修正: `FORGE_DASHBOARD_TOKEN` が設定されており、リクエストに有効な
+`Authorization: Bearer <token>` ヘッダーがある場合、オリジンチェックをバイパスします
+（トークン認証が CSRF 保護に取って代わります）。
+
+**セキュリティモデル:**
+
+| モード | バインド | 認証 |
+| --- | --- | --- |
+| デフォルト（現在） | `127.0.0.1` | ループバック + 同一オリジン（変更なし） |
+| リモート（ngrok） | `127.0.0.1` | `FORGE_DASHBOARD_TOKEN` ベアラートークン |
+
+ngrok の設定例:
+
+```bash
+# ダッシュボード付きで MCP サーバーを起動
+FORGE_EVENTS_PORT=8099 FORGE_DASHBOARD_TOKEN=<secret> forge-state-mcp
+
+# 別のターミナルで ngrok 経由で公開
+ngrok http 8099 --request-header-add "Authorization: Bearer <secret>"
+```
+
+---
+
+## フェーズ2: Web UI からのタスク投入（リサーチ）
+
+Web UI からタスクを投入するにはプログラム的な Claude セッションが必要です。
+`claude --print`（`-p`）はステートレスであり、マルチターンのパイプライン会話には
+適していません。適切なツールは **Anthropic Agent SDK** です。これはプログラム的に
+完全なツール使用付きのマルチターン会話をサポートします。
+
+### アーキテクチャ
+
+```text
+Web UI  ──  POST /api/task/submit  ──▶  ダッシュボードサーバー
+                                              │
+                                        タスクをキューに追加
+                                              │
+                                        タスクランナー
+                                        （Agent SDK）
+                                              │
+                                        マルチターンエージェントセッション
+                                        forge パイプラインを実行
+                                              │
+                                        .specs/ ワークスペース
+                                        state.json  ←──────  同じ EventBus
+                                                             同じダッシュボード SSE
+```
+
+Agent SDK 実行パイプラインは同じ `state.json` に書き込み、同じ `EventBus` に発行する
+ため、ダッシュボードの SSE ストリームとチェックポイント承認メカニズムは、インタラクティブ
+（Claude Code）と SDK 実行の両パイプラインで同一に動作します。コントロールプレーンは
+統一されます。
+
+### タスク投入エンドポイント
+
+```json
+POST /api/task/submit
+{
+  "input":  "https://github.com/org/repo/issues/42",
+  "effort": "M",
+  "flags":  ["--auto"]
+}
+```
+
+タスク ID を返します。タスクはダッシュボードに新しいパイプラインとして表示され、
+同じ SSE + チェックポイントフローで監視・承認できます。
+
+### forge-queue との統合
+
+`forge-queue` 設計（`queue-design.md` 参照）は `claude -p` サブプロセスを通じた
+逐次バッチ実行をカバーしています。フェーズ2はそのモデルを拡張し、ダッシュボード
+駆動のタスク投入と SDK ベースの実行をサポートします:
+
+- `forge-queue` → `claude -p` による逐次バッチ、ダッシュボード投入なし
+- フェーズ2 → ダッシュボードからのオンデマンド投入、SDK ベース実行
+
+これらは共存可能です。ダッシュボードのタスク投入エンドポイントは同じランナーのキューに
+追加するだけです。
+
+### フェーズ2に必要なもの
+
+- Anthropic Agent SDK 統合（Python または TypeScript ランナー、または Go SDK）
+- 永続的タスクランナーサービス（別プロセスまたはゴルーチンプール）
+- タスクキューの永続化（シンプルなファイルベースまたはインメモリ）
+- ダッシュボード: タスク投入フォーム + タスク一覧ビュー
+- 認証強化（エンドポイントがタスク入力を受け付けるためトークンベース必須）
+
+フェーズ2は独立した取り組みです。ここでは実装計画を提供しません。
+
+---
+
+## 実装ロードマップ
+
+### フェーズ1（今すぐ実装）
+
+1. **`pipeline_next_action.go`**: `currentPhaseStatus == "awaiting_human"` かつ
+   `user_response` なしの場合に EventBus ロングポールを追加。
+   - `bus`（すでにハンドラーに渡されている）を購読。
+   - EventBus チャネル（現在のフェーズの `phase-complete`）、15 秒ティッカー、
+     `ctx.Done()` を select。
+   - マッチした場合: ステート再読込、エンジン実行、`PhaseStart` 呼出し、アクション返却。
+   - タイムアウト: `still_waiting: true` のチェックポイントアクションを返却。
+
+2. **`SKILL.md`**: チェックポイントアクションハンドラー — `AskUserQuestion` を削除し、
+   `still_waiting: true` での即時再呼出しループを追加。
+
+3. **`intervention.go`**: オプションのベアラートークンミドルウェアを追加。
+   - サーバー起動時に環境変数から `FORGE_DASHBOARD_TOKEN` を読込。
+   - 設定済みの場合: `Authorization: Bearer <token>` が一致すれば任意のオリジンを許可;
+     不一致の場合は拒否（ループバックに関わらず）。
+   - 未設定の場合: 既存の `isLocalRequest` の動作は変更なし。
+
+4. **`dashboard.html`**: 承認後の UX — "approved" ボタンラベルを
+   "✓ Pipeline will continue automatically" に変更。
+
+### フェーズ2（将来）
+
+Agent SDK ベースのタスクランナーとダッシュボード投入フォームを独立した取り組みとして
+設計・実装します。

--- a/docs/research/remote-dashboard-control.md
+++ b/docs/research/remote-dashboard-control.md
@@ -1,0 +1,258 @@
+# Remote Dashboard Control
+
+Status: draft v1 (2026-04-18)
+
+## Overview
+
+This document explores the architecture required to allow the forge Dashboard to
+be accessed from external devices (smartphone, tablet, remote machine) and to
+have checkpoint approvals automatically resume the Claude pipeline — without
+requiring any terminal input.
+
+## Problem Statement
+
+### Current flow
+
+```text
+Claude (terminal)          Dashboard (browser)         state.json
+       │                          │                         │
+       │── pipeline_next_action ──▶ engine: checkpoint      │
+       │                          │                         │
+       │── checkpoint() ──────────────────────────────────▶ │ status=awaiting_human
+       │                          │                         │
+       │  [AskUserQuestion]       │── approve button ──────▶│ PhaseComplete()
+       │  blocking on             │                         │ status=pending (next phase)
+       │  terminal input          │   "approved" ✓          │
+       │                          │                         │
+       │  [nothing happens]       │                         │
+       │  still blocked           │                         │
+```
+
+When the user clicks "approve" in the Dashboard, `sm.PhaseComplete()` advances
+`state.json` to the next phase. However, Claude is blocked on `AskUserQuestion`
+waiting for terminal input. The approval is written to state, but Claude never
+wakes up.
+
+Additionally, the Dashboard server binds to `127.0.0.1` only, so access from
+external devices is not possible without changes.
+
+### Goals
+
+1. Dashboard approval automatically resumes the pipeline — no terminal action required.
+2. Dashboard accessible from external devices (smartphone, remote machine) via ngrok.
+3. Foundation for multi-pipeline monitoring and task submission (Phase 2).
+
+---
+
+## Phase 1: EventBus Long-Poll + Remote Access
+
+### Core mechanism: EventBus long-poll in `pipeline_next_action`
+
+Instead of SKILL.md blocking on `AskUserQuestion` at checkpoints, the MCP tool
+itself waits for a state change. When `pipeline_next_action` is called while
+`currentPhaseStatus == "awaiting_human"` and no `user_response` is provided:
+
+1. The handler subscribes to the in-process `EventBus`.
+2. Waits up to **N seconds** (e.g. 15 s — safely within MCP tool-call timeout)
+   for a `phase-complete` event on the current checkpoint phase.
+3. **Event arrives** (Dashboard called `PhaseComplete` → EventBus published):
+   reload state → `eng.NextAction` → `sm.PhaseStart` → return the next real
+   action (e.g. `spawn_agent` for phase-4). Claude proceeds with no terminal
+   interaction.
+4. **Timeout elapses** with no event: return `{type: "checkpoint",
+   still_waiting: true}` with the same checkpoint presentation text.
+
+```text
+Claude (no AskUserQuestion)        MCP server                  Dashboard
+       │                                │                           │
+       │── pipeline_next_action() ─────▶│                           │
+       │                                │ subscribe EventBus        │
+       │   [MCP call blocked]           │ wait up to 15s            │
+       │                                │                           │
+       │                                │◀── PhaseComplete() ───────│ user clicks approve
+       │                                │ event: phase-complete      │
+       │                                │ reload state              │
+       │                                │ eng.NextAction            │
+       │◀─ {type: "spawn_agent"} ───────│ PhaseStart               │
+       │                                │                           │
+       │  continue pipeline             │                           │
+```
+
+If no Dashboard approval arrives within 15 s, the tool returns `still_waiting:
+true`. SKILL.md calls `pipeline_next_action` again immediately (no sleep, no
+terminal prompt). The 15 s server-side delay provides natural pacing.
+
+### Terminal user path
+
+The terminal path is unaffected in correctness, with a max 15 s delay:
+
+1. Claude is blocked on the `pipeline_next_action` long-poll.
+2. User types "proceed" in terminal → Claude Code queues the message.
+3. After 15 s (or earlier if Dashboard fires), the tool returns `still_waiting:
+   true`.
+4. Claude processes the queued "proceed" → calls
+   `pipeline_next_action(user_response="proceed")`.
+5. P8 block calls `sm.PhaseComplete` + the engine returns the next action.
+
+### SKILL.md change (minimal)
+
+The only SKILL.md change is the checkpoint action handler:
+
+```text
+- `checkpoint`: Call checkpoint(). Output action.present_to_user + Dashboard URL.
+  Then immediately call pipeline_next_action() (no user_response, no AskUserQuestion).
+  - If still_waiting: true  → call pipeline_next_action() again immediately.
+  - If non-checkpoint action returned → Dashboard approved; proceed normally.
+  - User may type in terminal at any time; their message is processed after the
+    current pipeline_next_action() call returns (max 15 s delay).
+```
+
+### Changes summary
+
+| Component | Change | Scope |
+| --- | --- | --- |
+| `pipeline_next_action.go` | Add long-poll path when `awaiting_human` + no `user_response` | Medium |
+| `SKILL.md` | Replace `AskUserQuestion` with immediate re-call on `still_waiting` | Small |
+| `dashboard.html` | After approve: show "Pipeline will continue automatically" | Trivial |
+| `intervention.go` | Optional: bearer token auth (`FORGE_DASHBOARD_TOKEN`) | Small |
+
+### Remote access via ngrok
+
+No server binding changes are required. The Dashboard stays on `127.0.0.1`.
+ngrok forwards external traffic to the local port:
+
+```text
+smartphone browser
+       │
+       ▼ HTTPS
+  ngrok tunnel (e.g. https://abc123.ngrok.io)
+       │
+       ▼ HTTP (loopback)
+  127.0.0.1:8099  ←  forge Dashboard server
+```
+
+The `isLocalRequest` guard in `intervention.go` sees only the ngrok agent's
+loopback connection and passes it through unchanged.
+
+The `Origin` header from the browser will be the ngrok URL, which currently
+fails the same-origin check. Fix: when `FORGE_DASHBOARD_TOKEN` is set and the
+request carries a valid `Authorization: Bearer <token>` header, bypass the
+origin check entirely — token auth supersedes CSRF protection.
+
+**Security model:**
+
+| Mode | Binding | Auth |
+| --- | --- | --- |
+| Default (current) | `127.0.0.1` | loopback + same-origin (unchanged) |
+| Remote (ngrok) | `127.0.0.1` | `FORGE_DASHBOARD_TOKEN` bearer token |
+
+Setting up ngrok:
+
+```bash
+# start the MCP server with dashboard
+FORGE_EVENTS_PORT=8099 FORGE_DASHBOARD_TOKEN=<secret> forge-state-mcp
+
+# in another terminal, expose via ngrok
+ngrok http 8099 --request-header-add "Authorization: Bearer <secret>"
+# or use ngrok basic auth and set the token on the server side
+```
+
+---
+
+## Phase 2: Task Submission from Web UI (research)
+
+Submitting tasks from the Web UI requires a programmatic Claude session.
+`claude --print` (`-p`) is stateless and unsuitable for multi-turn pipeline
+conversations. The correct tool is the **Anthropic Agent SDK**, which supports
+multi-turn conversations with full tool-use programmatically.
+
+### Architecture
+
+```text
+Web UI  ──  POST /api/task/submit  ──▶  Dashboard server
+                                              │
+                                        enqueue task
+                                              │
+                                        task runner
+                                        (Agent SDK)
+                                              │
+                                        multi-turn agent session
+                                        runs forge pipeline
+                                              │
+                                        .specs/ workspace
+                                        state.json  ←──────  same EventBus
+                                                             same Dashboard SSE
+```
+
+Because the Agent SDK-run pipeline writes to the same `state.json` and publishes
+to the same `EventBus`, the Dashboard's SSE stream and checkpoint approval
+mechanism work identically for both interactive (Claude Code) and SDK-run
+pipelines. The control plane is unified.
+
+### Task submission endpoint
+
+```json
+POST /api/task/submit
+{
+  "input":  "https://github.com/org/repo/issues/42",
+  "effort": "M",
+  "flags":  ["--auto"]
+}
+```
+
+Returns a task ID. The task appears in the Dashboard as a new pipeline and can
+be monitored and approved through the same SSE + checkpoint flow.
+
+### Integration with forge-queue
+
+The `forge-queue` design (see `queue-design.md`) already covers sequential
+batch execution via `claude -p` subprocesses. Phase 2 extends that model to
+support SDK-based execution with Dashboard-driven task submission:
+
+- `forge-queue` → sequential batch via `claude -p`, no Dashboard submission
+- Phase 2 → on-demand submission from Dashboard, SDK-based execution
+
+These can coexist. The Dashboard task submission endpoint simply enqueues into
+the same runner.
+
+### What Phase 2 requires
+
+- Anthropic Agent SDK integration (Python or TypeScript runner, or Go SDK if
+  available)
+- A persistent task runner service (separate process or goroutine pool)
+- Task queue persistence (simple file-based or in-memory)
+- Dashboard: task submission form + task list view
+- Authentication hardening (token-based, since the endpoint accepts task inputs)
+
+Phase 2 is a separate initiative. No implementation plan is provided here.
+
+---
+
+## Implementation Roadmap
+
+### Phase 1 (implement now)
+
+1. **`pipeline_next_action.go`**: Add EventBus long-poll when
+   `currentPhaseStatus == "awaiting_human"` and no `user_response` provided.
+   - Subscribe to `bus` (already threaded into the handler).
+   - Select on: EventBus channel (`phase-complete` for current phase), 15 s
+     ticker, `ctx.Done()`.
+   - On match: reload state, run engine, call `PhaseStart`, return action.
+   - On timeout: return checkpoint action with `still_waiting: true`.
+
+2. **`SKILL.md`**: Checkpoint action handler — remove `AskUserQuestion`, add
+   immediate re-call loop on `still_waiting: true`.
+
+3. **`intervention.go`**: Add optional bearer token middleware.
+   - Read `FORGE_DASHBOARD_TOKEN` from env at server start.
+   - If set: accept any origin when `Authorization: Bearer <token>` matches;
+     reject otherwise (regardless of loopback).
+   - If unset: existing `isLocalRequest` behavior unchanged.
+
+4. **`dashboard.html`**: Post-approve UX — replace "approved" button label
+   with "✓ Pipeline will continue automatically".
+
+### Phase 2 (future)
+
+Design and implement the Agent SDK-based task runner and Dashboard submission
+form as a separate initiative.

--- a/docs/research/remote-dashboard-control.md
+++ b/docs/research/remote-dashboard-control.md
@@ -154,7 +154,6 @@ FORGE_EVENTS_PORT=8099 FORGE_DASHBOARD_TOKEN=<secret> forge-state-mcp
 
 # in another terminal, expose via ngrok
 ngrok http 8099 --request-header-add "Authorization: Bearer <secret>"
-# or use ngrok basic auth and set the token on the server side
 ```
 
 ---

--- a/mcp-server/internal/dashboard/dashboard.html
+++ b/mcp-server/internal/dashboard/dashboard.html
@@ -166,7 +166,7 @@
       letter-spacing: 0.05em;
     }
     .out-completed { background: rgba(63, 185, 80, 0.15); color: var(--ok); }
-    .out-in_progress { background: rgba(88, 166, 255, 0.15); color: var(--accent); }
+    .out-in_progress { background: rgba(163, 113, 247, 0.15); color: var(--info); }
     .out-failed { background: rgba(248, 81, 73, 0.15); color: var(--bad); }
     .out-awaiting_human { background: rgba(210, 153, 34, 0.15); color: var(--warn); }
     .out-abandoned { background: rgba(139, 148, 158, 0.15); color: var(--muted); }


### PR DESCRIPTION
## Summary

- Adds research document covering the architecture for remote Dashboard control of claude-forge pipelines
- Core mechanism: EventBus long-poll inside `pipeline_next_action` so checkpoint approval from the Dashboard automatically resumes Claude without any terminal input
- Covers ngrok-based remote access, optional bearer token auth, and Phase 2 task submission via Anthropic Agent SDK
- English + Japanese translations, VitePress nav entries for both

## Key findings

- **Problem**: Dashboard "approve" calls `sm.PhaseComplete()` and advances `state.json`, but Claude is blocked on `AskUserQuestion` and never wakes up
- **Solution (Phase 1)**: `pipeline_next_action` subscribes to `EventBus` when `currentPhaseStatus == "awaiting_human"`, waits up to N seconds for a `phase-complete` event; on receipt, reloads state and returns the next real action. SKILL.md change is minimal: replace `AskUserQuestion` with immediate re-call on `still_waiting: true`
- **Remote access**: Dashboard stays on `127.0.0.1`; ngrok tunnels it. Bearer token (`FORGE_DASHBOARD_TOKEN`) replaces the loopback+same-origin check when set
- **Phase 2**: Task submission from Web UI requires Anthropic Agent SDK (not `claude -p`, which is stateless) — documented as a separate future initiative

## Test plan

- [ ] Review `docs/research/remote-dashboard-control.md` for accuracy and completeness
- [ ] Review Japanese translation `docs/ja/research/remote-dashboard-control.md`
- [ ] Verify VitePress nav links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)