### PR TITLE
feat(pipeline): absorb checkpoint state transition into pipeline_next_action

### DIFF
--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -43,7 +43,7 @@ Events are emitted **after** the corresponding `StateManager` method succeeds. N
 |---|---|
 | Phase start (`pending -> in_progress`) | `pipeline_next_action` |
 | Phase complete (`in_progress -> completed`) | `pipeline_report_result` via `determineTransition()` |
-| Checkpoint (`in_progress -> awaiting_human`) | `pipeline_next_action` (absorbed; calls `sm.Checkpoint()` internally) |
+| Checkpoint (`in_progress -> awaiting_human`) | `pipeline_next_action` (checkpoint action) |
 | Checkpoint resolution | `pipeline_next_action` (with `user_response`) |
 
 ### 5. Event pairs

--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -43,7 +43,7 @@ Events are emitted **after** the corresponding `StateManager` method succeeds. N
 |---|---|
 | Phase start (`pending -> in_progress`) | `pipeline_next_action` |
 | Phase complete (`in_progress -> completed`) | `pipeline_report_result` via `determineTransition()` |
-| Checkpoint (`in_progress -> awaiting_human`) | `pipeline_next_action` (checkpoint action) |
+| Checkpoint (`in_progress -> awaiting_human`) | `pipeline_next_action` (absorbed; calls `sm.Checkpoint()` internally) |
 | Checkpoint resolution | `pipeline_next_action` (with `user_response`) |
 
 ### 5. Event pairs

--- a/cspell.json
+++ b/cspell.json
@@ -10,6 +10,7 @@
     "nopr",
     "afplay",
     "hiromaily",
-    "frontmatter"
+    "frontmatter",
+    "SSOT"
   ]
 }

--- a/docs/architecture/mcp-protocol-constraints.md
+++ b/docs/architecture/mcp-protocol-constraints.md
@@ -1,0 +1,3 @@
+# MCP Protocol Constraints
+
+<!--@include: ../../template/sections/architecture/mcp-protocol-constraints.md-->

--- a/docs/ja/architecture/mcp-protocol-constraints.md
+++ b/docs/ja/architecture/mcp-protocol-constraints.md
@@ -1,0 +1,3 @@
+# MCP プロトコル制約
+
+<!--@include: ../../template/sections/architecture/mcp-protocol-constraints.md-->

--- a/docs/ja/research/remote-dashboard-control.md
+++ b/docs/ja/research/remote-dashboard-control.md
@@ -1,6 +1,6 @@
 # ダッシュボードのリモートコントロール
 
-Status: draft v3 (2026-04-19)
+Status: **Phase 1 実装済み** (2026-04-20)。チェックポイント吸収、EventBus ロングポーリング（50 秒）、ローカルネットワークアクセスが稼働中。実装仕様は `docs/superpowers/specs/2026-04-20-checkpoint-absorption-design.md` を参照。
 
 ## 概要
 

--- a/docs/research/remote-dashboard-control.md
+++ b/docs/research/remote-dashboard-control.md
@@ -1,6 +1,6 @@
 # Remote Dashboard Control
 
-Status: draft v3 (2026-04-19)
+Status: **Phase 1 implemented** (2026-04-20). Checkpoint absorption, EventBus long-poll (50 s), and local network access are live. See `docs/superpowers/specs/2026-04-20-checkpoint-absorption-design.md` for the implementation spec.
 
 ## Overview
 

--- a/docs/superpowers/plans/2026-04-20-checkpoint-absorption.md
+++ b/docs/superpowers/plans/2026-04-20-checkpoint-absorption.md
@@ -1,0 +1,398 @@
+# Checkpoint Absorption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Dashboard checkpoint approval deterministic by absorbing the `checkpoint()` state transition into `pipeline_next_action` and extending the long-poll from 15s to 50s.
+
+**Architecture:** Replace the `sm2.Update()` call that only sets `CurrentPhaseStatus` with `sm2.Checkpoint()` that sets both `CurrentPhase` and `CurrentPhaseStatus`. Extend the long-poll timeout constant from 15s to 50s. Update SKILL.md to remove the `checkpoint()` MCP tool call instruction.
+
+**Tech Stack:** Go 1.26, mcp-go, existing EventBus/StateManager
+
+**Spec:** `docs/superpowers/specs/2026-04-20-checkpoint-absorption-design.md`
+
+---
+
+### Task 1: Extend long-poll timeout from 15s to 50s
+
+**Files:**
+
+- Modify: `mcp-server/internal/handler/tools/pipeline_next_action.go:27-29`
+
+- [ ] **Step 1: Update the timeout constant**
+
+In `mcp-server/internal/handler/tools/pipeline_next_action.go`, change line 27-29:
+
+```go
+// Before:
+// checkpointLongPollTimeout is the maximum time pipeline_next_action blocks
+// waiting for a Dashboard-triggered phase-complete event at a checkpoint.
+// 15 seconds is safely within the MCP tool-call timeout on all observed clients.
+const checkpointLongPollTimeout = 15 * time.Second
+
+// After:
+// checkpointLongPollTimeout is the maximum time pipeline_next_action blocks
+// waiting for a Dashboard-triggered phase-complete event at a checkpoint.
+// 50 seconds provides a 10-second margin against the default 60-second MCP
+// tool-call timeout. See docs/architecture/mcp-protocol-constraints.md.
+const checkpointLongPollTimeout = 50 * time.Second
+```
+
+- [ ] **Step 2: Run tests to verify no regressions**
+
+Run: `cd mcp-server && go test -race ./internal/handler/tools/... -count=1 -run TestPipelineNextAction`
+
+Expected: All existing tests pass. The long-poll tests use `context.WithTimeout` for short-circuiting, so the 50s constant does not affect test execution time.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge add mcp-server/internal/handler/tools/pipeline_next_action.go
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge commit -m "perf(pipeline): extend checkpoint long-poll timeout from 15s to 50s"
+```
+
+---
+
+### Task 2: Absorb checkpoint state transition into `pipeline_next_action`
+
+**Files:**
+
+- Modify: `mcp-server/internal/handler/tools/pipeline_next_action.go:570-585`
+
+- [ ] **Step 1: Replace `sm2.Update()` with `sm2.Checkpoint()`**
+
+In `mcp-server/internal/handler/tools/pipeline_next_action.go`, replace lines 570-585:
+
+```go
+// Before (lines 570-585):
+		// Eliminate the window between pipeline_next_action returning a checkpoint action
+		// and the orchestrator calling mcp__forge-state__checkpoint().
+		// Set currentPhaseStatus to "awaiting_human" immediately so the stop hook permits
+		// session exit even if the conversation ends before the orchestrator calls checkpoint().
+		if action.Type == orchestrator.ActionCheckpoint {
+			if updateErr := sm2.Update(func(s *state.State) error {
+				s.CurrentPhaseStatus = "awaiting_human"
+				return nil
+			}); updateErr != nil {
+				// Fail-open: warn but still return the action.
+				appendWarning(fmt.Sprintf("set awaiting_human: %v", updateErr))
+			}
+			if st, stErr := sm2.GetState(); stErr == nil {
+				publishEvent(bus, nil, "checkpoint", action.Phase, st.SpecName, workspace, "awaiting_human")
+			}
+		}
+```
+
+Replace with:
+
+```go
+// After:
+		// Absorb the checkpoint state transition that was previously done by the
+		// standalone checkpoint() MCP tool. sm2.Checkpoint() sets both CurrentPhase
+		// and CurrentPhaseStatus=awaiting_human, which is a superset of the previous
+		// Update() that only set CurrentPhaseStatus. This eliminates the need for
+		// the orchestrator to call checkpoint() as a separate MCP tool call.
+		if action.Type == orchestrator.ActionCheckpoint {
+			if chkErr := sm2.Checkpoint(workspace, action.Phase); chkErr != nil {
+				// Fail-open: warn but still return the action.
+				appendWarning(fmt.Sprintf("Checkpoint: %v", chkErr))
+			}
+			if st, stErr := sm2.GetState(); stErr == nil {
+				publishEvent(bus, nil, "checkpoint", action.Phase, st.SpecName, workspace, "awaiting_human")
+			}
+		}
+```
+
+- [ ] **Step 2: Run tests to verify no regressions**
+
+Run: `cd mcp-server && go test -race ./internal/handler/tools/... -count=1`
+
+Expected: All existing tests pass. The `TestPipelineNextAction_LongPoll` test pre-sets `CurrentPhaseStatus = awaiting_human`, so the absorption code path (which runs on the *first* call, before `awaiting_human` is set) does not interfere with existing long-poll tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge add mcp-server/internal/handler/tools/pipeline_next_action.go
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge commit -m "feat(pipeline): absorb checkpoint state transition into pipeline_next_action"
+```
+
+---
+
+### Task 3: Add tests for checkpoint absorption
+
+**Files:**
+
+- Modify: `mcp-server/internal/handler/tools/pipeline_next_action_test.go`
+
+- [ ] **Step 1: Write test for checkpoint absorption setting `awaiting_human`**
+
+Add the following test after the existing `TestPipelineNextAction_LongPoll_Timeout` function (after line 1637):
+
+```go
+// TestPipelineNextAction_CheckpointAbsorption verifies that when
+// pipeline_next_action returns an ActionCheckpoint, the handler internally
+// calls sm.Checkpoint() to set CurrentPhaseStatus=awaiting_human and
+// CurrentPhase to the checkpoint phase — without requiring a separate
+// checkpoint() MCP tool call.
+func TestPipelineNextAction_CheckpointAbsorption(t *testing.T) {
+	t.Parallel()
+
+	// Set up workspace at checkpoint-a with status=in_progress (not yet awaiting_human).
+	// This simulates the first pipeline_next_action call that encounters a checkpoint.
+	workspace, sm := initWorkspaceForNextAction(t, state.PhaseCheckpointA, func(s *state.State) error {
+		s.CurrentPhaseStatus = state.StatusInProgress
+		// Mark prerequisite phases as completed so the engine returns ActionCheckpoint.
+		s.CompletedPhases = []string{
+			state.PhaseOne, state.PhaseTwo, state.PhaseThree, state.PhaseThreeB,
+		}
+		return nil
+	})
+	bus := events.NewEventBus()
+	eng := orchestrator.NewEngine("", "")
+	h := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+
+	result, err := callNextAction(t, h, workspace)
+	if err != nil {
+		t.Fatalf("PipelineNextActionHandler: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("PipelineNextActionHandler returned error: %s", textContent(result))
+	}
+
+	var resp nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result)), &resp); jsonErr != nil {
+		t.Fatalf("unmarshal response: %v", jsonErr)
+	}
+	if resp.Type != orchestrator.ActionCheckpoint {
+		t.Fatalf("action type = %q, want %q", resp.Type, orchestrator.ActionCheckpoint)
+	}
+
+	// Verify that the handler absorbed the checkpoint: state on disk should now
+	// have CurrentPhaseStatus=awaiting_human AND CurrentPhase=checkpoint-a.
+	sm2 := state.NewStateManager("dev")
+	if err := sm2.LoadFromFile(workspace); err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	st, err := sm2.GetState()
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if st.CurrentPhaseStatus != state.StatusAwaitingHuman {
+		t.Errorf("CurrentPhaseStatus = %q, want %q", st.CurrentPhaseStatus, state.StatusAwaitingHuman)
+	}
+	if st.CurrentPhase != state.PhaseCheckpointA {
+		t.Errorf("CurrentPhase = %q, want %q", st.CurrentPhase, state.PhaseCheckpointA)
+	}
+}
+```
+
+- [ ] **Step 2: Write test verifying long-poll works without separate `checkpoint()` call**
+
+Add the following test:
+
+```go
+// TestPipelineNextAction_CheckpointAbsorption_ThenLongPoll verifies the
+// two-phase flow: first call absorbs checkpoint (returns ActionCheckpoint),
+// second call enters long-poll and wakes on Dashboard approval.
+func TestPipelineNextAction_CheckpointAbsorption_ThenLongPoll(t *testing.T) {
+	t.Parallel()
+
+	workspace, sm := initWorkspaceForNextAction(t, state.PhaseCheckpointA, func(s *state.State) error {
+		s.CurrentPhaseStatus = state.StatusInProgress
+		s.CompletedPhases = []string{
+			state.PhaseOne, state.PhaseTwo, state.PhaseThree, state.PhaseThreeB,
+		}
+		return nil
+	})
+	bus := events.NewEventBus()
+	eng := orchestrator.NewEngine("", "")
+	h := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+
+	// Phase 1: first call absorbs the checkpoint.
+	result1, err := callNextAction(t, h, workspace)
+	if err != nil {
+		t.Fatalf("1st call: %v", err)
+	}
+	var resp1 nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result1)), &resp1); jsonErr != nil {
+		t.Fatalf("unmarshal 1st: %v", jsonErr)
+	}
+	if resp1.Type != orchestrator.ActionCheckpoint {
+		t.Fatalf("1st call type = %q, want checkpoint", resp1.Type)
+	}
+
+	// Phase 2: second call should enter long-poll (state is now awaiting_human).
+	// Simulate Dashboard approval after a short delay.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		sm2 := state.NewStateManager("dev")
+		if loadErr := sm2.LoadFromFile(workspace); loadErr != nil {
+			return
+		}
+		_ = sm2.PhaseComplete(workspace, state.PhaseCheckpointA)
+		bus.Publish(events.Event{
+			Event:     "phase-complete",
+			Phase:     "checkpoint-a",
+			Workspace: workspace,
+			Outcome:   "completed",
+		})
+	}()
+
+	// Create a fresh handler with a fresh StateManager for the 2nd call
+	// (mimics pipeline_next_action's per-call sm2 creation).
+	h2 := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+	result2, err := callNextAction(t, h2, workspace)
+	if err != nil {
+		t.Fatalf("2nd call: %v", err)
+	}
+
+	var resp2 nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result2)), &resp2); jsonErr != nil {
+		t.Fatalf("unmarshal 2nd: %v", jsonErr)
+	}
+	if resp2.StillWaiting {
+		t.Error("2nd call: StillWaiting=true, expected Dashboard approval to wake long-poll")
+	}
+	if resp2.Type == orchestrator.ActionCheckpoint {
+		t.Errorf("2nd call type = %q, want non-checkpoint action after approval", resp2.Type)
+	}
+}
+```
+
+- [ ] **Step 3: Write test verifying timeout constant is 50s**
+
+Add the following test:
+
+```go
+// TestCheckpointLongPollTimeout_Is50s documents the timeout constant value.
+// If this test fails, the MCP protocol constraints document
+// (docs/architecture/mcp-protocol-constraints.md) must also be updated.
+func TestCheckpointLongPollTimeout_Is50s(t *testing.T) {
+	t.Parallel()
+	if checkpointLongPollTimeout != 50*time.Second {
+		t.Errorf("checkpointLongPollTimeout = %v, want 50s", checkpointLongPollTimeout)
+	}
+}
+```
+
+- [ ] **Step 4: Run all new tests**
+
+Run: `cd mcp-server && go test -race ./internal/handler/tools/... -count=1 -run "TestPipelineNextAction_CheckpointAbsorption|TestCheckpointLongPollTimeout"`
+
+Expected: All 3 new tests pass.
+
+- [ ] **Step 5: Run full test suite to verify no regressions**
+
+Run: `cd mcp-server && go test -race ./... -count=1`
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge add mcp-server/internal/handler/tools/pipeline_next_action_test.go
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge commit -m "test(pipeline): add checkpoint absorption and long-poll timeout tests"
+```
+
+---
+
+### Task 4: Update SKILL.md checkpoint handling
+
+**Files:**
+
+- Modify: `skills/forge/SKILL.md:112-149`
+
+- [ ] **Step 1: Replace the checkpoint action handler in SKILL.md**
+
+In `skills/forge/SKILL.md`, replace lines 112-149 (the `checkpoint` action handler) with:
+
+```text
+   - `checkpoint`: Present `action.present_to_user` to the user.
+     Mention that the Dashboard can be used to approve without terminal input.
+     Then **immediately** call `mcp__forge-state__pipeline_next_action(workspace)`
+     (no `user_response`, no `previous_*`). The server long-polls up to 50 s
+     waiting for a Dashboard approval event.
+     - If the response has `still_waiting: true`: call `pipeline_next_action(workspace)`
+       again immediately (no `user_response`). Repeat until a non-checkpoint action is
+       returned or the user provides a terminal response.
+     - If the user types a response in the terminal (proceed / revise / abandon) while
+       still_waiting is looping: on the next `pipeline_next_action` call, pass
+       `user_response=<response>` instead of looping.
+     - If a non-checkpoint action is returned: Dashboard approved; proceed normally.
+     - **Special: `post-to-source` checkpoint** — when `action.name`
+       is `"post-to-source"`:
+       1. Ask the user whether to post the work report (use AskUserQuestion
+          with options "post" / "skip").
+       2. If the user chooses **"post"** and `action.post_method` is present:
+          a. Read the body content from `action.post_method.body_source`.
+          b. Post the comment using the method specified in `post_method`:
+             - If `post_method.mcp_tool` is set: call it with `post_method.mcp_params`
+               and the body content (pass body as the `body` parameter).
+             - Else if `post_method.command` is set: execute the command via Bash.
+             - Else if `post_method.instruction` is set: follow the instruction as a fallback guide.
+          c. Report success or failure to the user.
+       3. If the user chooses **"skip"**: do nothing.
+       Pass the user's response to `pipeline_next_action(workspace, user_response=<response>)`.
+     Do NOT call `checkpoint()` — `pipeline_next_action` handles the checkpoint
+     state transition internally.
+     On every `pipeline_next_action` call for a checkpoint (still_waiting loops and
+     terminal-response call alike), omit `previous_action_complete` (or pass false),
+     and pass `previous_tokens=0, previous_duration_ms=0` with no `previous_model`
+     or `previous_setup_only`
+     (checkpoints have no agent cost; omitting `previous_action_complete` causes the P5 block to be skipped).
+```
+
+- [ ] **Step 2: Update the Rules section reference to long-poll duration**
+
+In `skills/forge/SKILL.md`, line 186, update "This is the Dashboard long-poll loop" to reference 50s:
+
+```text
+- When `still_waiting: true` is returned: call `pipeline_next_action(workspace)` again immediately with no `previous_*` or `user_response`. This is the Dashboard long-poll loop (50 s per iteration) — keep calling until a non-still_waiting response arrives or the user types a terminal response.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge add skills/forge/SKILL.md
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge commit -m "feat(skill): remove checkpoint() call, simplify checkpoint handling in SKILL.md"
+```
+
+---
+
+### Task 5: Update pipeline rule in `.claude/rules/pipeline.md`
+
+**Files:**
+
+- Modify: `.claude/rules/pipeline.md`
+
+- [ ] **Step 1: Update the ownership table**
+
+In `.claude/rules/pipeline.md`, update the ownership table to reflect that `pipeline_next_action` now owns the checkpoint state transition:
+
+Find the table:
+
+```markdown
+| Responsibility | Owner |
+|---|---|
+| Phase start (`pending -> in_progress`) | `pipeline_next_action` |
+| Phase complete (`in_progress -> completed`) | `pipeline_report_result` via `determineTransition()` |
+| Checkpoint (`in_progress -> awaiting_human`) | `pipeline_next_action` (checkpoint action) |
+| Checkpoint resolution | `pipeline_next_action` (with `user_response`) |
+```
+
+Update the Checkpoint row comment:
+
+```markdown
+| Responsibility | Owner |
+|---|---|
+| Phase start (`pending -> in_progress`) | `pipeline_next_action` |
+| Phase complete (`in_progress -> completed`) | `pipeline_report_result` via `determineTransition()` |
+| Checkpoint (`in_progress -> awaiting_human`) | `pipeline_next_action` (absorbed; calls `sm.Checkpoint()` internally) |
+| Checkpoint resolution | `pipeline_next_action` (with `user_response`) |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge add .claude/rules/pipeline.md
+git -C /Users/hiroki.yasui/go/src/github.com/legalforce/worktree2/dealon-app/poc/claude-forge commit -m "docs(rules): update pipeline ownership table for checkpoint absorption"
+```

--- a/docs/superpowers/specs/2026-04-20-checkpoint-absorption-design.md
+++ b/docs/superpowers/specs/2026-04-20-checkpoint-absorption-design.md
@@ -1,0 +1,230 @@
+# Checkpoint Absorption — Deterministic Dashboard Approval
+
+## Problem
+
+When a user clicks "Approve" on the Dashboard at an `AWAITING_HUMAN` checkpoint,
+the API succeeds (`✓ Pipeline will continue automatically`) but the terminal
+does not advance. Root cause analysis identified two issues:
+
+1. **Server-side (resolved)**: `approveCheckpointHandler` now publishes a
+   `phase-complete` event to the EventBus, and `pipeline_next_action` long-polls
+   for this event. The server-side wiring is correct.
+
+2. **Orchestrator-side (this design)**: The orchestrator (Claude Code LLM)
+   must implement a `still_waiting` polling loop per SKILL.md instructions.
+   LLMs are non-deterministic — the orchestrator may use `AskUserQuestion`
+   instead, or fail to re-call `pipeline_next_action`, leaving no subscriber
+   listening for the Dashboard event.
+
+Additionally, the current flow requires 3 MCP tool calls before the long-poll
+starts (`pipeline_next_action` → `checkpoint()` → `pipeline_next_action`),
+increasing the surface area for LLM deviation.
+
+## Goal
+
+- Make Dashboard checkpoint approval work deterministically
+- Reduce LLM-dependent steps from 3 tool calls to 2
+- Extend the long-poll window to minimize re-call iterations
+- Document MCP protocol constraints as SSOT for future design decisions
+
+## Design
+
+### 1. Checkpoint Absorption into `pipeline_next_action`
+
+Absorb the `checkpoint()` MCP tool's state transition into `pipeline_next_action`
+so the orchestrator never needs to call `checkpoint()` separately.
+
+**Current flow (3 tool calls + LLM loop)**:
+
+```text
+Orchestrator              MCP Server               Dashboard
+    │                         │                        │
+    │─ pipeline_next_action ─▶│                        │
+    │◀─ ActionCheckpoint ─────│                        │
+    │                         │                        │
+    │─ checkpoint() ─────────▶│ sm.Checkpoint()        │  ← redundant
+    │◀─ "ok" ────────────────│                        │
+    │                         │                        │
+    │─ pipeline_next_action ─▶│ long-poll 15s          │
+    │◀─ still_waiting ───────│                        │  ← LLM must re-call
+    │                         │                        │
+    │─ pipeline_next_action ─▶│ long-poll 15s          │  ← non-deterministic
+    │                    .... │ ...                    │─ Approve
+    │◀─ next action ─────────│                        │
+```
+
+**Proposed flow (2 tool calls, 1st is instant)**:
+
+```text
+Orchestrator              MCP Server               Dashboard
+    │                         │                        │
+    │─ pipeline_next_action ─▶│                        │
+    │  (1st call)             │ sm.Checkpoint() absorbed│
+    │◀─ ActionCheckpoint ─────│ present_to_user + text │
+    │                         │                        │
+    │  [presents text]        │                        │
+    │                         │                        │
+    │─ pipeline_next_action ─▶│ long-poll 50s          │
+    │  (2nd call)             │                        │─ Approve (within 50s)
+    │◀─ next action ─────────│ event received, reload │
+    │                         │                        │
+    │  continue pipeline      │                        │
+```
+
+### 2. Code Changes
+
+#### 2.1 `pipeline_next_action.go` — Checkpoint absorption (L574-585)
+
+Replace the current `sm2.Update()` call with `sm2.Checkpoint()`:
+
+```go
+// Before:
+if action.Type == orchestrator.ActionCheckpoint {
+    sm2.Update(func(s *state.State) error {
+        s.CurrentPhaseStatus = "awaiting_human"
+        return nil
+    })
+    publishEvent(bus, nil, "checkpoint", ...)
+}
+
+// After:
+if action.Type == orchestrator.ActionCheckpoint {
+    if err := sm2.Checkpoint(workspace, action.Phase); err != nil {
+        appendWarning(fmt.Sprintf("Checkpoint: %v", err))
+    }
+    publishEvent(bus, nil, "checkpoint", ...)
+}
+```
+
+`sm.Checkpoint()` sets both `CurrentPhase` and `CurrentPhaseStatus = awaiting_human`,
+which is a superset of the current `Update()` that only sets `CurrentPhaseStatus`.
+
+#### 2.2 `pipeline_next_action.go` — Long-poll timeout extension
+
+```go
+// Before:
+const checkpointLongPollTimeout = 15 * time.Second
+
+// After:
+const checkpointLongPollTimeout = 50 * time.Second
+```
+
+50 seconds provides a 10-second margin against the default 60-second MCP tool
+call timeout. See `docs/architecture/mcp-protocol-constraints.md` for the
+rationale.
+
+#### 2.3 Long-poll entry condition (unchanged)
+
+The existing long-poll entry condition (L295-301) requires no changes:
+
+```go
+if userResponse == "" {
+    subID, eventCh := bus.Subscribe()
+    st, stErr := sm2.GetState()
+    if stErr == nil && st.CurrentPhaseStatus == state.StatusAwaitingHuman {
+        // enter long-poll
+    }
+}
+```
+
+- **1st call**: State loaded from disk is not yet `awaiting_human` → long-poll
+  skipped → ActionCheckpoint returned → checkpoint absorbed at L574
+- **2nd call**: State loaded from disk is `awaiting_human` → long-poll starts (50s)
+
+### 3. SKILL.md Changes
+
+Replace the current checkpoint handling (L112-149, 38 lines) with:
+
+```text
+- `checkpoint`: Present `action.present_to_user` to the user.
+  Mention that the Dashboard can be used to approve without terminal input.
+  Then immediately call `pipeline_next_action(workspace)` (no `user_response`,
+  no `previous_*`). The server long-polls up to 50s for Dashboard approval.
+  - If `still_waiting: true`: call `pipeline_next_action(workspace)` again
+    immediately. Repeat until a non-checkpoint action is returned.
+  - If the user types a response in the terminal (proceed / revise / abandon):
+    on the next call, pass `user_response=<response>`.
+  - If a non-checkpoint action is returned: proceed normally.
+  Do NOT call `checkpoint()` — pipeline_next_action handles the state
+  transition internally.
+```
+
+
+Key changes:
+
+- `checkpoint()` MCP tool call removed
+- Long-poll duration documented (50s)
+- post-to-source checkpoint special case preserved as-is
+- Terminal user response path unchanged (P8 block handles it)
+
+### 4. `--auto` Flag Compatibility
+
+No impact. When `--auto` conditions are met, the engine returns
+`ActionSpawnAgent` or `ActionDone` (skip) — never `ActionCheckpoint`.
+The absorption code only executes for `ActionCheckpoint`, so auto-skip
+paths are unaffected.
+
+| Condition | Engine return | Absorption code |
+| --------- | ------------- | --------------- |
+| `--auto` + APPROVE verdict | `ActionSpawnAgent` (phase-4) | Not reached |
+| `--auto` + phase-4 skipped | `ActionDone` (skip prefix) | Not reached |
+| No `--auto` or REVISE verdict | `ActionCheckpoint` | **Executed** |
+
+### 5. `CheckpointHandler` Retention
+
+The standalone `CheckpointHandler` (in `handlers.go`) is **not deleted**.
+It remains available for:
+
+- Manual debugging via MCP tool calls
+- Backward compatibility with older SKILL.md versions
+- The post-to-source checkpoint which uses a different flow
+
+SKILL.md no longer instructs the orchestrator to call it for standard
+checkpoints (checkpoint-a, checkpoint-b).
+
+### 6. Terminal User Path
+
+The terminal user response path is preserved via the existing P8 block
+(L198-257) in `pipeline_next_action`:
+
+1. Orchestrator presents checkpoint text (1st call return)
+2. Orchestrator calls `pipeline_next_action` → 50s long-poll (2nd call)
+3. User types "proceed" in terminal → Claude Code queues the message
+4. After 50s timeout, orchestrator processes queued message
+5. Next `pipeline_next_action(user_response="proceed")` → P8 handles it
+
+Maximum latency: 50s between user typing and pipeline advancing.
+Acceptable because checkpoints are review gates, not interactive prompts.
+
+## Test Strategy
+
+### Modified tests
+
+- `pipeline_next_action_test.go`: Update long-poll timeout references (15s → 50s)
+
+### New test cases
+
+| Test | Validates |
+| ---- | --------- |
+| `TestCheckpointAbsorption_SetsAwaitingHuman` | `sm.Checkpoint()` called internally, state is `awaiting_human` |
+| `TestCheckpointAbsorption_NoExternalCheckpointCall` | Long-poll works without separate `checkpoint()` call |
+| `TestLongPoll_50sTimeout` | Timeout constant is 50s |
+| `TestAutoApprove_BypassesAbsorption` | `--auto` + APPROVE → absorption code not reached |
+
+### Unaffected tests
+
+- `TestApproveCheckpoint_*` (intervention_test.go) — Dashboard API unchanged
+- `TestCheckpointHandlerPublishesEvent` (handlers_test.go) — handler retained
+- Hook tests (`test-hooks.sh`) — `awaiting_human` state unchanged
+
+## Impact Summary
+
+| Component | Change | Size |
+| --------- | ------ | ---- |
+| `pipeline_next_action.go` | Checkpoint absorption + long-poll 50s | Medium |
+| `pipeline_next_action_test.go` | New tests + timeout updates | Medium |
+| `SKILL.md` | Checkpoint handling simplification | Small |
+| `handlers.go` | No change (CheckpointHandler retained) | None |
+| `docs/architecture/mcp-protocol-constraints.md` | New: MCP constraint documentation | New |
+| `template/sections/architecture/mcp-protocol-constraints.md` | SSOT source | New |
+| `docs/ja/architecture/mcp-protocol-constraints.md` | Japanese translation | New |

--- a/mcp-server/internal/dashboard/intervention.go
+++ b/mcp-server/internal/dashboard/intervention.go
@@ -125,7 +125,7 @@ func approveCheckpointHandler(sm *state.StateManager, bus *events.EventBus, publ
 //
 // When publicMode is true the loopback/origin check is skipped (see approveCheckpointHandler).
 // An "abandon" event is published to the bus so any pipeline_next_action long-poll
-// at a checkpoint wakes up immediately rather than waiting the full 15-second timeout.
+// at a checkpoint wakes up immediately rather than waiting the full 50-second timeout.
 func abandonHandler(sm *state.StateManager, bus *events.EventBus, publicMode bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !publicMode && !isLocalRequest(r) {

--- a/mcp-server/internal/handler/tools/pipeline_e2e_test.go
+++ b/mcp-server/internal/handler/tools/pipeline_e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -695,4 +696,183 @@ func TestE2E_StateTransitions(t *testing.T) {
 	if len(phaseOrder) < 5 {
 		t.Errorf("only %d distinct phases observed, want >= 5; phases: %v", len(phaseOrder), phaseOrder)
 	}
+}
+
+// TestE2E_DashboardCheckpointApproval drives a full pipeline to completion
+// where checkpoints are approved via Dashboard (EventBus events) instead of
+// terminal user_response. This is the E2E verification that the checkpoint
+// absorption + long-poll mechanism works end-to-end.
+func TestE2E_DashboardCheckpointApproval(t *testing.T) {
+	t.Parallel()
+
+	// Custom setup: we need the shared EventBus to simulate Dashboard approval.
+	dir := t.TempDir()
+	sm := state.NewStateManager("dev")
+	if err := sm.Init(dir, "e2e-dashboard"); err != nil {
+		t.Fatalf("sm.Init: %v", err)
+	}
+	cfg := e2eConfig{
+		effort:      state.EffortM,
+		template:    state.TemplateStandard,
+		autoApprove: false,
+		skipPR:      true,
+	}
+	if err := sm.Configure(dir, state.PipelineConfig{
+		Effort:        cfg.effort,
+		FlowTemplate:  cfg.template,
+		AutoApprove:   cfg.autoApprove,
+		SkipPR:        cfg.skipPR,
+		SkippedPhases: orchestrator.SkipsForTemplate(cfg.template),
+	}); err != nil {
+		t.Fatalf("sm.Configure: %v", err)
+	}
+	if err := sm.Update(func(s *state.State) error {
+		s.BranchClassified = true
+		return nil
+	}); err != nil {
+		t.Fatalf("sm.Update: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(dir, state.ArtifactRequest),
+		[]byte("# Request\n\ntest task\n"),
+		0o600,
+	); err != nil {
+		t.Fatalf("write request.md: %v", err)
+	}
+
+	// Shared bus: both the handler and the Dashboard simulation goroutine use this.
+	bus := events.NewEventBus()
+	eng := orchestrator.NewEngine("", "")
+	kb := history.NewKnowledgeBase("")
+	nextActionH := PipelineNextActionHandler(sm, bus, eng, "", nil, kb, nil)
+	reportResultH := PipelineReportResultHandler(sm, bus, kb)
+
+	dashboardApprovedCheckpoints := 0
+
+	for iter := range 60 {
+		result, err := callNextAction(t, nextActionH, dir)
+		if err != nil {
+			t.Fatalf("iter %d: callNextAction Go error: %v", iter, err)
+		}
+		if result.IsError {
+			t.Fatalf("iter %d: callNextAction MCP error: %s", iter, textContent(result))
+		}
+
+		var resp nextActionResponse
+		if err := json.Unmarshal([]byte(textContent(result)), &resp); err != nil {
+			t.Fatalf("iter %d: unmarshal: %v", iter, err)
+		}
+		if resp.Action.Type == orchestrator.ActionDone {
+			break
+		}
+
+		reportPhase := resp.Action.Phase
+		if resp.Action.Type == orchestrator.ActionCheckpoint && reportPhase == "" {
+			reportPhase = resp.Action.Name
+		}
+
+		// When we hit a checkpoint, simulate Dashboard approval via EventBus
+		// instead of using callNextActionWithUserResponse.
+		if resp.Action.Type == orchestrator.ActionCheckpoint {
+			// Goroutine simulates a Dashboard user clicking "Approve" after 20ms.
+			// Reads CurrentPhase from disk (not action.Name) to match what
+			// approveCheckpointHandler does: it uses the phase stored in state.json,
+			// not the checkpoint label from the SSE event.
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				dashSM := state.NewStateManager("dev")
+				if loadErr := dashSM.LoadFromFile(dir); loadErr != nil {
+					return
+				}
+				dashSt, stErr := dashSM.GetState()
+				if stErr != nil {
+					return
+				}
+				_ = dashSM.PhaseComplete(dir, dashSt.CurrentPhase)
+				bus.Publish(events.Event{
+					Event:     "phase-complete",
+					Phase:     dashSt.CurrentPhase,
+					Workspace: dir,
+					Outcome:   "completed",
+				})
+			}()
+
+			// Call pipeline_next_action which enters the long-poll.
+			// The goroutine above wakes it by publishing the event.
+			result2, err2 := callNextAction(t, nextActionH, dir)
+			if err2 != nil {
+				t.Fatalf("iter %d (dashboard poll): Go error: %v", iter, err2)
+			}
+			if result2.IsError {
+				t.Fatalf("iter %d (dashboard poll): MCP error: %s", iter, textContent(result2))
+			}
+
+			var resp2 nextActionResponse
+			if err := json.Unmarshal([]byte(textContent(result2)), &resp2); err != nil {
+				t.Fatalf("iter %d (dashboard poll): unmarshal: %v", iter, err)
+			}
+			if resp2.StillWaiting {
+				t.Fatalf("iter %d: StillWaiting=true after Dashboard approval — event not received", iter)
+			}
+			if resp2.Action.Type == orchestrator.ActionDone {
+				dashboardApprovedCheckpoints++
+				break
+			}
+
+			dashboardApprovedCheckpoints++
+
+			// Continue with the post-approval action.
+			resp = resp2
+			reportPhase = resp.Action.Phase
+			if resp.Action.Type == orchestrator.ActionCheckpoint && reportPhase == "" {
+				reportPhase = resp.Action.Name
+			}
+		}
+
+		// Execute the action.
+		switch resp.Action.Type {
+		case orchestrator.ActionWriteFile:
+			if err := os.WriteFile(resp.Action.Path, []byte(resp.Action.Content), 0o600); err != nil {
+				t.Fatalf("write_file %s: %v", resp.Action.Path, err)
+			}
+		case orchestrator.ActionSpawnAgent:
+			approve := new(bool)
+			*approve = true
+			mockAgentExecute(t, dir, resp.Action, cfg, approve)
+		case orchestrator.ActionExec:
+			// no-op
+		case orchestrator.ActionCheckpoint:
+			// This shouldn't happen (handled above), but be safe.
+			t.Fatalf("unexpected checkpoint after dashboard approval: %s", resp.Action.Name)
+		default:
+			t.Fatalf("unhandled action type %q", resp.Action.Type)
+		}
+
+		// Report result to advance state.
+		reportRes := callTool(t, reportResultH, map[string]any{
+			"workspace":   dir,
+			"phase":       reportPhase,
+			"tokens_used": 500,
+			"duration_ms": 1000,
+			"model":       "sonnet",
+		})
+		if reportRes.IsError {
+			t.Fatalf("reportResult for %q: %s", reportPhase, textContent(reportRes))
+		}
+	}
+
+	// Verify: pipeline completed.
+	finalState, err := state.ReadState(dir)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if finalState.CurrentPhase != state.PhaseCompleted {
+		t.Errorf("currentPhase = %q, want %q", finalState.CurrentPhase, state.PhaseCompleted)
+	}
+
+	// Verify: at least one checkpoint was approved via Dashboard.
+	if dashboardApprovedCheckpoints == 0 {
+		t.Error("no checkpoints were approved via Dashboard — test did not exercise the target code path")
+	}
+	t.Logf("Dashboard-approved checkpoints: %d", dashboardApprovedCheckpoints)
 }

--- a/mcp-server/internal/handler/tools/pipeline_next_action.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action.go
@@ -284,7 +284,7 @@ func PipelineNextActionHandler(
 		// This eliminates the need for AskUserQuestion at checkpoints: the
 		// orchestrator calls pipeline_next_action immediately after presenting the
 		// checkpoint to the user, and the MCP call stays open until either the
-		// Dashboard approves or 15 s pass.
+		// Dashboard approves or 50 s pass.
 		//
 		// On timeout the function falls through to eng.NextAction (which returns the
 		// same checkpoint action) and sets StillWaiting=true so the orchestrator
@@ -296,7 +296,7 @@ func PipelineNextActionHandler(
 		if userResponse == "" {
 			// Subscribe before GetState to close the race window: if the dashboard
 			// acts between the state-check and Subscribe the event would be missed,
-			// causing a full 15-second timeout before the orchestrator sees the update.
+			// causing a full 50-second timeout before the orchestrator sees the update.
 			subID, eventCh := bus.Subscribe()
 			st, stErr := sm2.GetState()
 			if stErr == nil && st.CurrentPhaseStatus == state.StatusAwaitingHuman {

--- a/mcp-server/internal/handler/tools/pipeline_next_action.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action.go
@@ -568,20 +568,18 @@ func PipelineNextActionHandler(
 			}
 		}
 
-		// Eliminate the window between pipeline_next_action returning a checkpoint action
-		// and the orchestrator calling mcp__forge-state__checkpoint().
-		// Set currentPhaseStatus to "awaiting_human" immediately so the stop hook permits
-		// session exit even if the conversation ends before the orchestrator calls checkpoint().
+		// Absorb the checkpoint state transition that was previously done by the
+		// standalone checkpoint() MCP tool. sm2.Checkpoint() sets both CurrentPhase
+		// and CurrentPhaseStatus=awaiting_human, which is a superset of the previous
+		// Update() that only set CurrentPhaseStatus. This eliminates the need for
+		// the orchestrator to call checkpoint() as a separate MCP tool call.
 		if action.Type == orchestrator.ActionCheckpoint {
-			if updateErr := sm2.Update(func(s *state.State) error {
-				s.CurrentPhaseStatus = "awaiting_human"
-				return nil
-			}); updateErr != nil {
+			if chkErr := sm2.Checkpoint(workspace, action.Name); chkErr != nil {
 				// Fail-open: warn but still return the action.
-				appendWarning(fmt.Sprintf("set awaiting_human: %v", updateErr))
+				appendWarning(fmt.Sprintf("Checkpoint: %v", chkErr))
 			}
 			if st, stErr := sm2.GetState(); stErr == nil {
-				publishEvent(bus, nil, "checkpoint", action.Phase, st.SpecName, workspace, "awaiting_human")
+				publishEvent(bus, nil, "checkpoint", action.Name, st.SpecName, workspace, "awaiting_human")
 			}
 		}
 

--- a/mcp-server/internal/handler/tools/pipeline_next_action.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action.go
@@ -570,16 +570,20 @@ func PipelineNextActionHandler(
 
 		// Absorb the checkpoint state transition that was previously done by the
 		// standalone checkpoint() MCP tool. sm2.Checkpoint() sets both CurrentPhase
-		// and CurrentPhaseStatus=awaiting_human, which is a superset of the previous
-		// Update() that only set CurrentPhaseStatus. This eliminates the need for
-		// the orchestrator to call checkpoint() as a separate MCP tool call.
+		// and CurrentPhaseStatus=awaiting_human. We pass st.CurrentPhase (not
+		// action.Name) because mid-phase checkpoints (e.g. "design-approved" at
+		// phase-3b) have action.Name values that differ from CurrentPhase and would
+		// fail the Checkpoint() validation guard. The event uses action.Name for the
+		// checkpoint identifier.
 		if action.Type == orchestrator.ActionCheckpoint {
-			if chkErr := sm2.Checkpoint(workspace, action.Name); chkErr != nil {
-				// Fail-open: warn but still return the action.
-				appendWarning(fmt.Sprintf("Checkpoint: %v", chkErr))
-			}
 			if st, stErr := sm2.GetState(); stErr == nil {
+				if chkErr := sm2.Checkpoint(workspace, st.CurrentPhase); chkErr != nil {
+					// Fail-open: warn but still return the action.
+					appendWarning(fmt.Sprintf("Checkpoint: %v", chkErr))
+				}
 				publishEvent(bus, nil, "checkpoint", action.Name, st.SpecName, workspace, "awaiting_human")
+			} else {
+				appendWarning(fmt.Sprintf("Checkpoint GetState: %v", stErr))
 			}
 		}
 

--- a/mcp-server/internal/handler/tools/pipeline_next_action.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action.go
@@ -555,33 +555,30 @@ func PipelineNextActionHandler(
 			break
 		}
 
-		// When reaching a checkpoint without a rename, mark BranchClassified so the engine
-		// does not re-evaluate branch type on subsequent calls.
-		if action.Type == orchestrator.ActionCheckpoint {
-			if st2, stErr := sm2.GetState(); stErr == nil && !st2.BranchClassified {
-				if updateErr := sm2.Update(func(s *state.State) error {
-					s.BranchClassified = true
-					return nil
-				}); updateErr != nil {
-					appendWarning(fmt.Sprintf("set BranchClassified: %v", updateErr))
-				}
-			}
-		}
-
-		// Absorb the checkpoint state transition that was previously done by the
-		// standalone checkpoint() MCP tool. sm2.Checkpoint() sets both CurrentPhase
-		// and CurrentPhaseStatus=awaiting_human. We pass st.CurrentPhase (not
-		// action.Name) because mid-phase checkpoints (e.g. "design-approved" at
-		// phase-3b) have action.Name values that differ from CurrentPhase and would
-		// fail the Checkpoint() validation guard. The event uses action.Name for the
-		// checkpoint identifier.
+		// When reaching a checkpoint: mark BranchClassified so the engine does not
+		// re-evaluate branch type on subsequent calls, then absorb the checkpoint
+		// state transition (previously done by the standalone checkpoint() MCP tool).
+		// sm2.Checkpoint() sets CurrentPhaseStatus=awaiting_human. We pass
+		// st.CurrentPhase (not action.Name) because mid-phase checkpoints (e.g.
+		// "design-approved" at phase-3b) have action.Name values that differ from
+		// CurrentPhase and would fail the Checkpoint() validation guard. The event
+		// uses action.Name for the checkpoint identifier.
 		if action.Type == orchestrator.ActionCheckpoint {
 			if st, stErr := sm2.GetState(); stErr == nil {
+				if !st.BranchClassified {
+					if updateErr := sm2.Update(func(s *state.State) error {
+						s.BranchClassified = true
+						return nil
+					}); updateErr != nil {
+						appendWarning(fmt.Sprintf("set BranchClassified: %v", updateErr))
+					}
+				}
 				if chkErr := sm2.Checkpoint(workspace, st.CurrentPhase); chkErr != nil {
 					// Fail-open: warn but still return the action.
 					appendWarning(fmt.Sprintf("Checkpoint: %v", chkErr))
+				} else {
+					publishEvent(bus, nil, "checkpoint", action.Name, st.SpecName, workspace, "awaiting_human")
 				}
-				publishEvent(bus, nil, "checkpoint", action.Name, st.SpecName, workspace, "awaiting_human")
 			} else {
 				appendWarning(fmt.Sprintf("Checkpoint GetState: %v", stErr))
 			}

--- a/mcp-server/internal/handler/tools/pipeline_next_action.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action.go
@@ -25,8 +25,9 @@ import (
 
 // checkpointLongPollTimeout is the maximum time pipeline_next_action blocks
 // waiting for a Dashboard-triggered phase-complete event at a checkpoint.
-// 15 seconds is safely within the MCP tool-call timeout on all observed clients.
-const checkpointLongPollTimeout = 15 * time.Second
+// 50 seconds provides a 10-second margin against the default 60-second MCP
+// tool-call timeout. See docs/architecture/mcp-protocol-constraints.md.
+const checkpointLongPollTimeout = 50 * time.Second
 
 const similarPipelinesSearchLimit = 3
 

--- a/mcp-server/internal/handler/tools/pipeline_next_action_test.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action_test.go
@@ -1763,6 +1763,126 @@ func TestCheckpointLongPollTimeout_Is50s(t *testing.T) {
 	}
 }
 
+// TestPipelineNextAction_CheckpointAbsorption_MidPhase verifies that checkpoint
+// absorption works for mid-phase checkpoints where action.Name differs from
+// CurrentPhase. This is a regression test for the fix that changed
+// sm2.Checkpoint(workspace, action.Name) to sm2.Checkpoint(workspace, st.CurrentPhase).
+// Without the fix, sm2.Checkpoint("design-approved") would fail the validation
+// guard because "design-approved" != CurrentPhase "phase-3b".
+func TestPipelineNextAction_CheckpointAbsorption_MidPhase(t *testing.T) {
+	t.Parallel()
+
+	workspace, sm := initWorkspaceForNextAction(t, state.PhaseThreeB, func(s *state.State) error {
+		s.CurrentPhaseStatus = state.StatusInProgress
+		s.CompletedPhases = []string{
+			state.PhaseOne, state.PhaseTwo, state.PhaseThree,
+		}
+		return nil
+	})
+
+	// Write a review-design.md with APPROVE verdict so the engine returns
+	// a "design-approved" checkpoint (not a spawn_agent for revision).
+	reviewContent := "# Design Review\n\n## Verdict: APPROVE\n\nLooks good.\n"
+	if err := os.WriteFile(filepath.Join(workspace, state.ArtifactReviewDesign), []byte(reviewContent), 0o644); err != nil {
+		t.Fatalf("write review-design.md: %v", err)
+	}
+
+	bus := events.NewEventBus()
+	eng := orchestrator.NewEngine("", "")
+	h := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+
+	result, err := callNextAction(t, h, workspace)
+	if err != nil {
+		t.Fatalf("PipelineNextActionHandler: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("PipelineNextActionHandler returned error: %s", textContent(result))
+	}
+
+	var resp nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result)), &resp); jsonErr != nil {
+		t.Fatalf("unmarshal response: %v", jsonErr)
+	}
+	if resp.Type != orchestrator.ActionCheckpoint {
+		t.Fatalf("action type = %q, want %q", resp.Type, orchestrator.ActionCheckpoint)
+	}
+
+	// Verify checkpoint absorption: state on disk should have awaiting_human.
+	sm2 := state.NewStateManager("dev")
+	if err := sm2.LoadFromFile(workspace); err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	st, err := sm2.GetState()
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if st.CurrentPhaseStatus != state.StatusAwaitingHuman {
+		t.Errorf("CurrentPhaseStatus = %q, want %q", st.CurrentPhaseStatus, state.StatusAwaitingHuman)
+	}
+	// CurrentPhase should remain "phase-3b", NOT "design-approved".
+	if st.CurrentPhase != state.PhaseThreeB {
+		t.Errorf("CurrentPhase = %q, want %q (must not change to checkpoint name)", st.CurrentPhase, state.PhaseThreeB)
+	}
+}
+
+// TestPipelineNextAction_AutoApprove_BypassesAbsorption verifies that when
+// AutoApprove is true and the AI verdict is APPROVE, the engine returns
+// ActionSpawnAgent (not ActionCheckpoint), so the checkpoint absorption code
+// is never reached. This documents the --auto flag's checkpoint bypass behavior.
+func TestPipelineNextAction_AutoApprove_BypassesAbsorption(t *testing.T) {
+	t.Parallel()
+
+	workspace, sm := initWorkspaceForNextAction(t, state.PhaseThreeB, func(s *state.State) error {
+		s.CurrentPhaseStatus = state.StatusInProgress
+		s.AutoApprove = true
+		s.CompletedPhases = []string{
+			state.PhaseOne, state.PhaseTwo, state.PhaseThree,
+		}
+		return nil
+	})
+
+	// Write a review-design.md with APPROVE verdict.
+	reviewContent := "# Design Review\n\n## Verdict: APPROVE\n\nLooks good.\n"
+	if err := os.WriteFile(filepath.Join(workspace, state.ArtifactReviewDesign), []byte(reviewContent), 0o644); err != nil {
+		t.Fatalf("write review-design.md: %v", err)
+	}
+
+	bus := events.NewEventBus()
+	eng := orchestrator.NewEngine("", "")
+	h := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+
+	result, err := callNextAction(t, h, workspace)
+	if err != nil {
+		t.Fatalf("PipelineNextActionHandler: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("PipelineNextActionHandler returned error: %s", textContent(result))
+	}
+
+	var resp nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result)), &resp); jsonErr != nil {
+		t.Fatalf("unmarshal response: %v", jsonErr)
+	}
+	// Auto-approve should bypass checkpoint entirely — the engine returns
+	// a spawn_agent or task_init action, not a checkpoint.
+	if resp.Type == orchestrator.ActionCheckpoint {
+		t.Errorf("action type = %q with AutoApprove=true; expected non-checkpoint action", resp.Type)
+	}
+
+	// State should NOT be awaiting_human.
+	sm2 := state.NewStateManager("dev")
+	if err := sm2.LoadFromFile(workspace); err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	st, err := sm2.GetState()
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if st.CurrentPhaseStatus == state.StatusAwaitingHuman {
+		t.Errorf("CurrentPhaseStatus = %q with AutoApprove=true; should not be awaiting_human", st.CurrentPhaseStatus)
+	}
+}
+
 // TestExtractTaskNumber verifies the extractTaskNumber helper that is used to
 // resolve the {N} template variable in agent .md files.
 func TestExtractTaskNumber(t *testing.T) {

--- a/mcp-server/internal/handler/tools/pipeline_next_action_test.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action_test.go
@@ -1636,6 +1636,133 @@ func TestPipelineNextAction_LongPoll_Timeout(t *testing.T) {
 	}
 }
 
+// TestPipelineNextAction_CheckpointAbsorption verifies that when
+// pipeline_next_action encounters a checkpoint phase in StatusInProgress, it
+// internally calls sm.Checkpoint() (setting CurrentPhaseStatus=awaiting_human
+// and CurrentPhase to the checkpoint phase) without requiring a separate
+// checkpoint() MCP tool call.
+func TestPipelineNextAction_CheckpointAbsorption(t *testing.T) {
+	t.Parallel()
+
+	workspace, sm := initWorkspaceForNextAction(t, state.PhaseCheckpointA, func(s *state.State) error {
+		s.CurrentPhaseStatus = state.StatusInProgress
+		s.CompletedPhases = []string{
+			state.PhaseOne, state.PhaseTwo, state.PhaseThree, state.PhaseThreeB,
+		}
+		return nil
+	})
+	bus := events.NewEventBus()
+	eng := orchestrator.NewEngine("", "")
+	h := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+
+	result, err := callNextAction(t, h, workspace)
+	if err != nil {
+		t.Fatalf("PipelineNextActionHandler: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("PipelineNextActionHandler returned error: %s", textContent(result))
+	}
+
+	var resp nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result)), &resp); jsonErr != nil {
+		t.Fatalf("unmarshal response: %v", jsonErr)
+	}
+	if resp.Type != orchestrator.ActionCheckpoint {
+		t.Fatalf("action type = %q, want %q", resp.Type, orchestrator.ActionCheckpoint)
+	}
+
+	sm2 := state.NewStateManager("dev")
+	if err := sm2.LoadFromFile(workspace); err != nil {
+		t.Fatalf("LoadFromFile: %v", err)
+	}
+	st, err := sm2.GetState()
+	if err != nil {
+		t.Fatalf("GetState: %v", err)
+	}
+	if st.CurrentPhaseStatus != state.StatusAwaitingHuman {
+		t.Errorf("CurrentPhaseStatus = %q, want %q", st.CurrentPhaseStatus, state.StatusAwaitingHuman)
+	}
+	if st.CurrentPhase != state.PhaseCheckpointA {
+		t.Errorf("CurrentPhase = %q, want %q", st.CurrentPhase, state.PhaseCheckpointA)
+	}
+}
+
+// TestPipelineNextAction_CheckpointAbsorption_ThenLongPoll verifies the
+// two-phase flow: the first call absorbs the checkpoint (sets awaiting_human),
+// and the second call enters long-poll and wakes when a Dashboard approval
+// event is published.
+func TestPipelineNextAction_CheckpointAbsorption_ThenLongPoll(t *testing.T) {
+	t.Parallel()
+
+	workspace, sm := initWorkspaceForNextAction(t, state.PhaseCheckpointA, func(s *state.State) error {
+		s.CurrentPhaseStatus = state.StatusInProgress
+		s.CompletedPhases = []string{
+			state.PhaseOne, state.PhaseTwo, state.PhaseThree, state.PhaseThreeB,
+		}
+		return nil
+	})
+	bus := events.NewEventBus()
+	eng := orchestrator.NewEngine("", "")
+	h := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+
+	// Phase 1: first call absorbs the checkpoint.
+	result1, err := callNextAction(t, h, workspace)
+	if err != nil {
+		t.Fatalf("1st call: %v", err)
+	}
+	var resp1 nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result1)), &resp1); jsonErr != nil {
+		t.Fatalf("unmarshal 1st: %v", jsonErr)
+	}
+	if resp1.Type != orchestrator.ActionCheckpoint {
+		t.Fatalf("1st call type = %q, want checkpoint", resp1.Type)
+	}
+
+	// Phase 2: second call should enter long-poll (state is now awaiting_human).
+	// Simulate Dashboard approval after a short delay.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		sm2 := state.NewStateManager("dev")
+		if loadErr := sm2.LoadFromFile(workspace); loadErr != nil {
+			return
+		}
+		_ = sm2.PhaseComplete(workspace, state.PhaseCheckpointA)
+		bus.Publish(events.Event{
+			Event:     "phase-complete",
+			Phase:     "checkpoint-a",
+			Workspace: workspace,
+			Outcome:   "completed",
+		})
+	}()
+
+	// Create a fresh handler with a fresh StateManager for the 2nd call
+	h2 := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
+	result2, err := callNextAction(t, h2, workspace)
+	if err != nil {
+		t.Fatalf("2nd call: %v", err)
+	}
+
+	var resp2 nextActionResponse
+	if jsonErr := json.Unmarshal([]byte(textContent(result2)), &resp2); jsonErr != nil {
+		t.Fatalf("unmarshal 2nd: %v", jsonErr)
+	}
+	if resp2.StillWaiting {
+		t.Error("2nd call: StillWaiting=true, expected Dashboard approval to wake long-poll")
+	}
+	if resp2.Type == orchestrator.ActionCheckpoint {
+		t.Errorf("2nd call type = %q, want non-checkpoint action after approval", resp2.Type)
+	}
+}
+
+// TestCheckpointLongPollTimeout_Is50s documents and pins the timeout constant
+// so accidental changes are caught immediately.
+func TestCheckpointLongPollTimeout_Is50s(t *testing.T) {
+	t.Parallel()
+	if checkpointLongPollTimeout != 50*time.Second {
+		t.Errorf("checkpointLongPollTimeout = %v, want 50s", checkpointLongPollTimeout)
+	}
+}
+
 // TestExtractTaskNumber verifies the extractTaskNumber helper that is used to
 // resolve the {N} template variable in agent .md files.
 func TestExtractTaskNumber(t *testing.T) {

--- a/mcp-server/internal/handler/tools/pipeline_next_action_test.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action_test.go
@@ -1557,7 +1557,7 @@ func TestPipelineNextAction_LongPoll(t *testing.T) {
 	// Fire the "phase-complete" event in a goroutine after a short delay so the
 	// handler has time to enter the long-poll (bus.Subscribe) before the event
 	// arrives. Without the sleep the goroutine races against Subscribe: if Publish
-	// fires before Subscribe the event is dropped and the test waits 15 s.
+	// fires before Subscribe the event is dropped and the test waits 50 s.
 	go func() {
 		time.Sleep(20 * time.Millisecond)
 		// Advance state on disk the same way approveCheckpointHandler does.
@@ -1608,7 +1608,7 @@ func TestPipelineNextAction_LongPoll_Timeout(t *testing.T) {
 	eng := orchestrator.NewEngine("", "")
 	h := PipelineNextActionHandler(sm, bus, eng, "", nil, nil, nil)
 
-	// Do NOT publish any event — the long-poll should time out (default 15 s is
+	// Do NOT publish any event — the long-poll should time out (default 50 s is
 	// too long for a unit test; we rely on ctx cancellation instead).
 	// Cancel after 50 ms; the long-poll selects on ctx.Done() and returns still_waiting.
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -109,15 +109,11 @@ Repeat until done:
        In that case, use the Write tool to write the agent's final response text to
        `{workspace}/{action.output_file}` before calling `pipeline_next_action`.
        This ensures `pipeline_report_result` artifact validation always succeeds.
-   - `checkpoint`: **Before presenting anything to the user**, call
-     `mcp__forge-state__checkpoint(workspace, phase=action.name)`.
-     This is mandatory — it registers the pause so the pipeline can exit safely if
-     the user closes the conversation before responding. Never skip or defer this call.
-     Then present `action.present_to_user` to the user. Mention that the Dashboard
-     can be used to approve without terminal input.
-     **Immediately** call `mcp__forge-state__pipeline_next_action(workspace)` (no
-     `user_response`, no `previous_*`). The server blocks up to 15 s waiting for a
-     Dashboard approval event.
+   - `checkpoint`: Present `action.present_to_user` to the user.
+     Mention that the Dashboard can be used to approve without terminal input.
+     Then **immediately** call `mcp__forge-state__pipeline_next_action(workspace)`
+     (no `user_response`, no `previous_*`). The server long-polls up to 50 s
+     waiting for a Dashboard approval event.
      - If the response has `still_waiting: true`: call `pipeline_next_action(workspace)`
        again immediately (no `user_response`). Repeat until a non-checkpoint action is
        returned or the user provides a terminal response.
@@ -139,9 +135,8 @@ Repeat until done:
           c. Report success or failure to the user.
        3. If the user chooses **"skip"**: do nothing.
        Pass the user's response to `pipeline_next_action(workspace, user_response=<response>)`.
-     The engine handles all checkpoint state transitions deterministically
-     (proceed → advance, revise → rewind, abandon → mark abandoned).
-     Do NOT call `phase_complete` for checkpoints — the engine owns the lifecycle.
+     Do NOT call `checkpoint()` — `pipeline_next_action` handles the checkpoint
+     state transition internally.
      On every `pipeline_next_action` call for a checkpoint (still_waiting loops and
      terminal-response call alike), omit `previous_action_complete` (or pass false),
      and pass `previous_tokens=0, previous_duration_ms=0` with no `previous_model`
@@ -183,6 +178,6 @@ Flags can also be set as persistent defaults via `/forge-setup`. Explicit flags 
 
 - Never make orchestration decisions independently — follow action.type exactly.
 - Always pass `previous_action_complete=true`, `previous_tokens`, `previous_duration_ms`, `previous_model`, and `previous_setup_only` on every `pipeline_next_action` call after the first (after any `spawn_agent`, `exec`, or `write_file` action completes). Do NOT pass `previous_action_complete=true` after a checkpoint — it must remain false (or omitted) to skip the P5 report block.
-- When `still_waiting: true` is returned: call `pipeline_next_action(workspace)` again immediately with no `previous_*` or `user_response`. This is the Dashboard long-poll loop — keep calling until a non-still_waiting response arrives or the user types a terminal response.
+- When `still_waiting: true` is returned: call `pipeline_next_action(workspace)` again immediately with no `previous_*` or `user_response`. This is the Dashboard long-poll loop (50 s per iteration) — keep calling until a non-still_waiting response arrives or the user types a terminal response.
 - Never pass `isolation: "worktree"` to any Agent call.
 - On MCP error: surface the error to the user and stop.

--- a/template/INDEX.md
+++ b/template/INDEX.md
@@ -100,6 +100,7 @@
 | sections/architecture/go-package-layering.md | Not referenced by any template |
 | sections/architecture/guard-catalogue.md | Not referenced by any template |
 | sections/architecture/hooks.md | Not referenced by any template |
+| sections/architecture/mcp-protocol-constraints.md | Not referenced by any template |
 | sections/architecture/overview-content.md | Not referenced by any template |
 | sections/architecture/pipeline-flow-guide.md | Not referenced by any template |
 | sections/architecture/pipeline-lifecycle-contract.md | Not referenced by any template |

--- a/template/sections/architecture/guard-catalogue.md
+++ b/template/sections/architecture/guard-catalogue.md
@@ -96,7 +96,7 @@ These behaviors are enforced **only** by LLM instructions. They cannot be guaran
 |---|---|---|
 | Never pass `isolation: "worktree"` to Agent calls | SKILL.md | Claude Code Agent tool parameter; no hook intercept point for Agent tool arguments |
 | Always call `pipeline_report_result` after `spawn_agent`, `exec`, `write_file` | SKILL.md | Omission is a no-op (missing metric), not a state corruption; adding a timeout guard would add complexity disproportionate to risk |
-| Wait for human response before calling `phase_complete` on checkpoints | SKILL.md | The **wait** itself is prompt-only, but the **gate** is deterministic: Guard 3e blocks `phase_complete` unless `checkpoint()` was called first, so the LLM cannot skip the checkpoint even if it doesn't wait |
+| Wait for Dashboard or terminal response at checkpoints | SKILL.md | `pipeline_next_action` absorbs the checkpoint state transition and long-polls for Dashboard approval (50 s). The LLM must re-call `pipeline_next_action` on `still_waiting`; the long-poll reduces iterations to minimize non-determinism |
 | Parse `skip:` prefix from `done` action and call `phase_complete` | SKILL.md | Engine returns the skip signal; if the orchestrator fails to parse it, `pipeline_next_action` returns the same skip signal again (self-correcting loop) |
 
 ## Dual-layer Enforcement Map

--- a/template/sections/architecture/mcp-protocol-constraints.md
+++ b/template/sections/architecture/mcp-protocol-constraints.md
@@ -1,0 +1,59 @@
+## MCP Protocol Constraints
+
+This document captures the protocol-level constraints of MCP (Model Context Protocol) that shape forge-state's architecture. These are hard constraints — they cannot be worked around without changes to the MCP specification or the host application (Claude Code).
+
+### Transport Model
+
+MCP uses JSON-RPC 2.0 over stdio (stdin/stdout). The transport is strictly **request-response**:
+
+- The **client** (Claude Code) initiates all tool calls.
+- The **server** (forge-state) can only respond to requests — it cannot push data to the client unprompted.
+- Server-to-client notifications exist (`notifications/message` for logging, `notifications/tools/list_changed` for tool discovery) but cannot carry arbitrary data or trigger client-side actions.
+
+**Implication**: The server cannot notify the client when an external event occurs (e.g., a Dashboard user clicks "Approve"). The client must poll or long-poll for state changes.
+
+### Tool Call Timeout
+
+Claude Code enforces a **default 60-second timeout** on MCP tool calls. Configurable via the `MCP_TIMEOUT` environment variable (value in milliseconds):
+
+```bash
+MCP_TIMEOUT=120000 claude  # 2-minute timeout
+```
+
+**Implication**: Long-poll durations inside MCP tool handlers must stay below this threshold. forge-state uses 50 seconds (10-second safety margin) for checkpoint long-polls.
+
+### No Streaming Responses
+
+MCP tool calls return a single `CallToolResult`. There is no mechanism for streaming partial results or sending multiple response chunks from a single tool invocation.
+
+**Implication**: A tool call that needs to both present data and wait for a subsequent event cannot do so in a single call. This requires a two-phase pattern: return data on the first call, long-poll on the second call.
+
+### Orchestrator Is an LLM
+
+The MCP client is driven by an LLM (Claude) interpreting SKILL.md instructions. This introduces non-determinism:
+
+- The LLM may deviate from prescribed tool-call sequences.
+- Polling loops (`if still_waiting, call again`) are unreliable because the LLM may instead ask the user for input.
+- The fewer tool calls required for a given workflow, the more deterministic the outcome.
+
+**Implication**: Design patterns should minimize the number of LLM-dependent tool calls. Absorb multi-step workflows into single tool calls where possible. When polling is unavoidable, maximize the poll duration to minimize iterations.
+
+### Design Patterns for forge-state
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| **Long-poll absorption** | Block inside a tool handler waiting for an event, rather than returning and expecting the LLM to re-call | `pipeline_next_action` checkpoint long-poll (50s) |
+| **Internal state transitions** | Perform state transitions inside the tool handler rather than requiring the LLM to call a separate tool | Checkpoint absorption: `pipeline_next_action` calls `sm.Checkpoint()` internally |
+| **P1-P7 dispatch loops** | Absorb skip, task_init, batch_commit, rename_branch, push_branch actions internally without returning to the LLM | `pipeline_next_action` P1-P7 loops |
+| **Two-phase checkpoint** | 1st call: return checkpoint text (instant). 2nd call: long-poll for approval (50s) | Checkpoint-a, checkpoint-b |
+
+### Timeout Calculation
+
+```
+MCP_TIMEOUT (default 60s) - safety_margin (10s) = long_poll_timeout (50s)
+```
+
+The 10-second margin accounts for:
+- JSON serialization/deserialization overhead
+- Network latency (negligible for stdio, but defensive)
+- State reload and engine computation after the long-poll wakes up

--- a/template/sections/architecture/pipeline-lifecycle-contract.md
+++ b/template/sections/architecture/pipeline-lifecycle-contract.md
@@ -104,22 +104,26 @@ PhaseCompleteHandler
 
 ### Path 3: Checkpoint Flow
 
-Human-review gates. `pipeline_next_action` detects checkpoint phases and sets `awaiting_human` via `sm.Update()` (not `sm.Checkpoint()` — the standalone checkpoint handler is a separate MCP tool). The orchestrator presents the checkpoint to the user and passes the response back.
+Human-review gates. `pipeline_next_action` detects checkpoint phases and absorbs the checkpoint state transition by calling `sm.Checkpoint(workspace, st.CurrentPhase)`, which sets both `CurrentPhase` and `CurrentPhaseStatus = "awaiting_human"`. The orchestrator presents the checkpoint to the user. On the next `pipeline_next_action` call, the handler long-polls (up to 50 s) for a Dashboard approval event; if the user responds via terminal, the response is passed as `user_response`.
 
 ```
 pipeline_next_action (checkpoint action detected)
-  ├── sm.Update(): CurrentPhaseStatus = "awaiting_human"
+  ├── sm.Checkpoint(): CurrentPhaseStatus = "awaiting_human"
+  ├── publish "checkpoint" event
   └── return Action{type: "checkpoint"} to orchestrator
 
-[user reviews and responds]
+pipeline_next_action (2nd call, no user_response)
+  ├── long-poll up to 50 s for Dashboard "phase-complete" event
+  ├── Dashboard approves → reload state → return next action
+  └── timeout → return Action{type: "checkpoint", still_waiting: true}
 
-pipeline_next_action (with user_response)
+pipeline_next_action (with user_response from terminal)
   ├── "proceed" → sm.PhaseComplete(workspace, phase)
   ├── "revise"  → sm.Update() to rewind state
   └── "abandon" → sm.Abandon()
 ```
 
-**Note**: The standalone `CheckpointHandler` (`handlers.go`) calls `sm.Checkpoint()` and emits a `checkpoint` event. The pipeline engine path uses `sm.Update()` directly. Both result in `CurrentPhaseStatus = "awaiting_human"` but through different code paths.
+**Note**: The standalone `CheckpointHandler` (`handlers.go`) is retained for manual debugging and backward compatibility but is no longer called by the orchestrator for standard checkpoints (checkpoint-a, checkpoint-b). The pipeline engine path now uses `sm.Checkpoint()` directly.
 
 ## Event Taxonomy
 

--- a/template/sections/ja/architecture/guard-catalogue.md
+++ b/template/sections/ja/architecture/guard-catalogue.md
@@ -94,7 +94,7 @@ claude-forge は4つの強制レイヤーを使用しており、最も信頼性
 |---|---|---|
 | Agent 呼び出しに `isolation: "worktree"` を渡さない | SKILL.md | Claude Code の Agent ツールパラメータ；Agent ツール引数のフックインターセプトポイントがない |
 | `spawn_agent`、`exec`、`write_file` の後に常に `pipeline_report_result` を呼び出す | SKILL.md | 省略は no-op（メトリクス欠落）であり、状態の破損ではない；タイムアウトガードを追加するとリスクに対して不釣り合いな複雑さが加わる |
-| チェックポイントで `phase_complete` を呼び出す前に人間の応答を待つ | SKILL.md | **待機**自体はプロンプトのみだが、**ゲート**は決定的：ガード 3e は `checkpoint()` が最初に呼び出されない限り `phase_complete` をブロックするため、LLM はチェックポイントをスキップできない |
+| チェックポイントで Dashboard または terminal の応答を待つ | SKILL.md | `pipeline_next_action` がチェックポイントの状態遷移を吸収し、Dashboard 承認をロングポーリング（50 秒）する。LLM は `still_waiting` 時に `pipeline_next_action` を再呼び出しする必要がある；ロングポーリングにより反復回数を削減し非決定性を最小化 |
 | `done` アクションの `skip:` プレフィックスを解析して `phase_complete` を呼び出す | SKILL.md | エンジンがスキップシグナルを返す；オーケストレーターが解析に失敗した場合、`pipeline_next_action` は同じスキップシグナルを再び返す（自己修正ループ） |
 
 ## デュアルレイヤー強制マップ

--- a/template/sections/ja/architecture/pipeline-lifecycle-contract.md
+++ b/template/sections/ja/architecture/pipeline-lifecycle-contract.md
@@ -104,22 +104,26 @@ PhaseCompleteHandler
 
 ### パス 3: チェックポイントフロー
 
-ヒューマンレビューゲート。`pipeline_next_action` はチェックポイントフェーズを検出し、`sm.Update()` を介して `awaiting_human` を設定する（`sm.Checkpoint()` ではない — スタンドアロンチェックポイントハンドラは別の MCP ツール）。オーケストレーターがユーザーにチェックポイントを提示し、レスポンスを返す。
+ヒューマンレビューゲート。`pipeline_next_action` はチェックポイントフェーズを検出し、`sm.Checkpoint(workspace, st.CurrentPhase)` を呼び出してチェックポイントの状態遷移を吸収する。これにより `CurrentPhase` と `CurrentPhaseStatus = "awaiting_human"` の両方が設定される。オーケストレーターがユーザーにチェックポイントを提示する。次の `pipeline_next_action` 呼び出しでは、ハンドラが最大 50 秒間 Dashboard 承認イベントをロングポーリングする。ユーザーが terminal で応答した場合は `user_response` として渡される。
 
 ```
 pipeline_next_action (チェックポイントアクション検出)
-  |-- sm.Update(): CurrentPhaseStatus = "awaiting_human"
+  |-- sm.Checkpoint(): CurrentPhaseStatus = "awaiting_human"
+  |-- "checkpoint" イベント発行
   └-- return Action{type: "checkpoint"} to orchestrator
 
-[ユーザーがレビューして応答]
+pipeline_next_action (2回目の呼び出し、user_response なし)
+  |-- Dashboard の "phase-complete" イベントを最大 50 秒ロングポーリング
+  |-- Dashboard 承認 -> 状態リロード -> 次アクション返却
+  └-- タイムアウト -> return Action{type: "checkpoint", still_waiting: true}
 
-pipeline_next_action (user_response 付き)
+pipeline_next_action (terminal からの user_response 付き)
   |-- "proceed" -> sm.PhaseComplete(workspace, phase)
   |-- "revise"  -> sm.Update() で状態を巻き戻し
   └-- "abandon" -> sm.Abandon()
 ```
 
-**注記**: スタンドアロンの `CheckpointHandler` (`handlers.go`) は `sm.Checkpoint()` を呼び `checkpoint` イベントを発行する。パイプラインエンジンパスは `sm.Update()` を直接使用する。両方とも `CurrentPhaseStatus = "awaiting_human"` となるが、異なるコードパスを通る。
+**注記**: スタンドアロンの `CheckpointHandler` (`handlers.go`) はデバッグおよび後方互換性のために保持されるが、標準チェックポイント（checkpoint-a、checkpoint-b）ではオーケストレーターから呼び出されなくなった。パイプラインエンジンパスは `sm.Checkpoint()` を直接使用する。
 
 ## イベント分類
 


### PR DESCRIPTION
## Summary

- `pipeline_next_action` now directly sets `currentPhaseStatus: "awaiting_human"` for checkpoint actions, eliminating the need for the orchestrator to call a separate `checkpoint()` MCP tool
- Extended checkpoint long-poll timeout from 15s to 50s for better Dashboard responsiveness
- Simplified `SKILL.md` by removing the now-redundant `checkpoint()` call from the orchestrator flow

## Test Plan
- [ ] E2E test: Dashboard checkpoint approval via long-poll passes
- [ ] Mid-phase checkpoint and auto-approve bypass tests pass
- [ ] Checkpoint absorption and long-poll timeout tests pass
- [ ] All Go tests: `cd mcp-server && go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)