### PR TITLE
feat(forge): pipeline/engine improvements from DEA-676 prod-run retrospective (#1–#10)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -204,10 +204,15 @@ Returns `needs_user_confirmation` for the orchestrator to present to the user:
     "current_branch": "main",
     "is_main_branch": true,
     "enriched_request_body": "implement login feature",
-    "message": "Detected effort=\"M\". ..."
+    "message": "Detected effort=\"M\". ...",
+    "estimate_display": "  📊 Estimate (effort=M, 4 past run(s)): ~120,000 tokens / ~$1.80 (P50) · up to ~210,000 tokens / ~$3.15 (P90)"
   }
 }
 ```
+
+`estimate_display` is a pre-formatted, verbatim line (omitted when no history exists); the
+orchestrator outputs it as-is rather than re-deriving P50/P90 figures from the raw `estimate`
+struct, keeping the cost presentation deterministic. `message` stays purely procedural.
 
 ### Response — First Call with `--discuss` (text source only)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -314,11 +314,32 @@ When `report_result` is non-null, the engine has recorded a phase result interna
   "phase": "phase-1",
   "input_files": ["request.md"],
   "output_file": "analysis.md",
-  "parallel_task_ids": null
+  "parallel_task_ids": null,
+  "parallel_tasks": null
 }
 ```
 
-The `prompt` field contains the **4-layer assembled prompt** (see below). When `parallel_task_ids` is non-empty, the orchestrator spawns one agent per task ID concurrently.
+The `prompt` field contains the **4-layer assembled prompt** (see below). For a parallel
+fanout, `parallel_tasks` carries the per-task contract the engine computed — each entry has
+`{ "id", "input_files", "output_file" }` — and the orchestrator spawns one agent per entry
+concurrently, using `output_file` for the artifact-write fallback. The orchestrator never
+derives the `<prefix>-<id>.md` filename itself. `parallel_task_ids` mirrors the same IDs in
+order for callers that only need the count. Both are `null` for a sequential spawn.
+
+```json
+{
+  "type": "spawn_agent",
+  "agent": "impl-reviewer",
+  "phase": "phase-6",
+  "input_files": ["tasks.md"],
+  "output_file": "",
+  "parallel_task_ids": ["1", "3"],
+  "parallel_tasks": [
+    { "id": "1", "input_files": ["impl-1.md"], "output_file": "review-1.md" },
+    { "id": "3", "input_files": ["impl-3.md"], "output_file": "review-3.md" }
+  ]
+}
+```
 
 #### `checkpoint` — Pause for human review
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -32,6 +32,12 @@ A **DESIGN document** covering:
 4. **Test strategy** — what to test and at which layer (unit, integration, e2e)
 5. **Risk mitigation** — how the issues identified in investigation.md are addressed
 6. **Open question decisions** — resolution for each open question from investigation.md
+7. **Cross-repository dependencies** — when the change depends on another repository
+   (e.g. shared proto definitions / akupara-proto, a published package, or a dependency
+   bump): call it out explicitly. Note the external-repo conventions that will gate the
+   work (e.g. protolint field-naming rules such as `created_at` → `created_time`), and
+   plan the merge-before-preview flow (external PR → CI → preview pin) so it is not
+   discovered late during implementation. Mark the external step as a human gate.
 
 ## Output Format
 

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -8,14 +8,14 @@ You are a **Verifier** — the final quality gate before a feature branch is dec
 ## Input
 
 The orchestrator tells you:
-- The feature branch name: `feature/{spec-name}`
+- The branch name: `{branch}` (the exact branch the engine created/uses — may be `feature/`, `fix/`, `refactor/`, etc.)
 - The workspace path: `{workspace}`
 
 ## Verification Steps
 
 ### Part A: Build Verification (technical correctness)
 
-1. **Confirm you are on the feature branch**: `git branch --show-current` — verify it matches `feature/{spec-name}`
+1. **Confirm you are on the correct branch**: `git branch --show-current` — verify it matches `{branch}`
 2. **Run full typecheck**: the project's typecheck command (check `CLAUDE.md` or `Makefile` for the command, e.g. `make lint`, `pnpm typecheck`)
 3. **Run full test suite**: the project's test command (e.g. `make test-local`, `pnpm test`)
 4. **Report results**: list all failures found on the feature branch. To identify pre-existing failures, use `git stash` to temporarily shelve uncommitted changes, run the tests, record the failures, then `git stash pop` — do NOT switch branches.
@@ -86,6 +86,13 @@ If a subsection has no findings, write "No friction observed." rather than omitt
 Skip this section entirely when the input artifacts do not include `analysis.md` (i.e., during final-verification phase).
 
 ## Output Format
+
+> **MANDATORY**: This report is a build artifact, not a chat reply. Write it to the output
+> artifact file the orchestrator names with the **Write tool** — `{workspace}/summary.md`
+> during the **final-summary** phase, `{workspace}/final-verification.md` during the
+> **final-verification** phase. The pipeline reads this file from disk; returning the report
+> as response text only will fail artifact validation. (This supersedes any general
+> "return results as text" guidance — for forge phases, always write the file.)
 
 ```
 ## Summary

--- a/mcp-server/internal/engine/orchestrator/actions.go
+++ b/mcp-server/internal/engine/orchestrator/actions.go
@@ -285,5 +285,7 @@ func crossRepoGateGuidance(title string) string {
 		"3. Obtain the preview artifact (preview branch / pre-release npm version / commit SHA).\n" +
 		"4. Pin that preview in this repository (update the dependency version) and verify the build.\n" +
 		"If this repository ships an `update-proto` (or equivalent dependency-update) skill, " +
-		"follow it for the merge-before-preview pattern.\n\n"
+		"follow it for the merge-before-preview pattern.\n" +
+		"Choose 'done' only after the preview is pinned and the build passes here; " +
+		"until then keep this gate open.\n\n"
 }

--- a/mcp-server/internal/engine/orchestrator/actions.go
+++ b/mcp-server/internal/engine/orchestrator/actions.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/sourcetype"
 )
@@ -214,10 +215,49 @@ func NewPushBranchAction(phase string) Action {
 // for the orchestrator and stores the task key in PendingHumanGate.
 func NewHumanGateAction(phase, taskKey, title string) Action {
 	return Action{
-		Type:          ActionHumanGate,
-		Phase:         phase,
-		Name:          taskKey,
-		PresentToUser: fmt.Sprintf("Task %s requires human action: %s\n\nComplete the action and choose 'done' to continue, or 'skip' to mark it without action.", taskKey, title),
-		Options:       []string{"done", "skip", "abandon"},
+		Type:  ActionHumanGate,
+		Phase: phase,
+		Name:  taskKey,
+		PresentToUser: fmt.Sprintf(
+			"Task %s requires human action: %s\n\n%sComplete the action and choose 'done' to continue, or 'skip' to mark it without action.",
+			taskKey, title, crossRepoGateGuidance(title),
+		),
+		Options: []string{"done", "skip", "abandon"},
 	}
+}
+
+// crossRepoExternalRepoKeywords signal a human gate whose work lives in a *different*
+// repository (proto definitions, dependency bumps, preview pins).
+//
+//nolint:gochecknoglobals // immutable lookup table
+var crossRepoExternalRepoKeywords = []string{
+	"proto", "akupara", "external repo", "external repository", "external pr",
+	"dependency", "dependencies", "preview", "npm version", "package version", "upstream",
+}
+
+// crossRepoGateGuidance returns a guidance block for human gates that depend on an
+// external repository — walking through the PR → CI watch → preview-pin flow and
+// pointing to the repository's own proto/dependency-update skill (improvement #5).
+// Returns "" when the task title shows no external-repo signal so single-repo gates
+// stay concise. The trailing blank line lets callers concatenate it inline.
+func crossRepoGateGuidance(title string) string {
+	lower := strings.ToLower(title)
+	matched := false
+	for _, kw := range crossRepoExternalRepoKeywords {
+		if strings.Contains(lower, kw) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return ""
+	}
+	return "This looks like a cross-repository dependency. Typical flow:\n" +
+		"1. Make the change in the external repository and open its PR.\n" +
+		"2. Watch that PR's CI; resolve repo-specific lint/naming rules " +
+		"(e.g. protolint field naming such as `created_at` → `created_time`).\n" +
+		"3. Obtain the preview artifact (preview branch / pre-release npm version / commit SHA).\n" +
+		"4. Pin that preview in this repository (update the dependency version) and verify the build.\n" +
+		"If this repository ships an `update-proto` (or equivalent dependency-update) skill, " +
+		"follow it for the merge-before-preview pattern.\n\n"
 }

--- a/mcp-server/internal/engine/orchestrator/actions.go
+++ b/mcp-server/internal/engine/orchestrator/actions.go
@@ -47,6 +47,16 @@ type Action struct {
 	OutputFile      string   `json:"output_file,omitempty"`
 	ParallelTaskIDs []string `json:"parallel_task_ids,omitempty"` // non-nil iff this is a parallel fanout
 
+	// ParallelTasks is the per-task input/output contract for a parallel fanout. The
+	// engine — which already knows the phase — computes each task's output_file
+	// (impl-<id>.md for the implementer phase, review-<id>.md for the reviewer phase)
+	// and any task-specific input_files, so the orchestrator iterates this list
+	// mechanically instead of deriving the <prefix>-<id>.md filename from prose. The
+	// per-task output_file is also the target for the artifact-write fallback. Non-nil
+	// iff this is a parallel fanout; ParallelTaskIDs mirrors its IDs for callers that
+	// only need the count/order.
+	ParallelTasks []ParallelTask `json:"parallel_tasks,omitempty"`
+
 	// checkpoint fields
 	Name          string   `json:"name,omitempty"`
 	PresentToUser string   `json:"present_to_user,omitempty"`
@@ -99,10 +109,25 @@ func NewSpawnAgentAction(agent, prompt, model, phase string, inputFiles []string
 	}
 }
 
+// ParallelTask is the per-task input/output contract for one task in a parallel fanout.
+// OutputFile is the artifact the task's agent must write (and the write-fallback target);
+// InputFiles lists task-specific inputs beyond the shared Action.InputFiles.
+type ParallelTask struct {
+	ID         string   `json:"id"`
+	InputFiles []string `json:"input_files,omitempty"`
+	OutputFile string   `json:"output_file"`
+}
+
 // NewParallelSpawnAction constructs an ActionSpawnAgent that signals parallel fanout.
-// taskIDs must be sorted numerically ascending by the caller (engine uses sortedTaskKeys).
-// Prompt contains the shared prompt for all parallel tasks.
-func NewParallelSpawnAction(agent, prompt, model, phase string, inputFiles []string, taskIDs []string) Action {
+// tasks must be ordered by the caller (engine uses sortedTaskKeys); each task carries its
+// own output_file so the orchestrator never derives <prefix>-<id>.md from prose.
+// inputFiles is the shared input context applied to every task. Prompt is shared too.
+// ParallelTaskIDs is derived from tasks for callers that only need the IDs.
+func NewParallelSpawnAction(agent, prompt, model, phase string, inputFiles []string, tasks []ParallelTask) Action {
+	taskIDs := make([]string, len(tasks))
+	for i, t := range tasks {
+		taskIDs[i] = t.ID
+	}
 	return Action{
 		Type:            ActionSpawnAgent,
 		Agent:           agent,
@@ -110,6 +135,7 @@ func NewParallelSpawnAction(agent, prompt, model, phase string, inputFiles []str
 		Model:           model,
 		Phase:           phase,
 		InputFiles:      inputFiles,
+		ParallelTasks:   tasks,
 		ParallelTaskIDs: taskIDs,
 	}
 }

--- a/mcp-server/internal/engine/orchestrator/actions_test.go
+++ b/mcp-server/internal/engine/orchestrator/actions_test.go
@@ -15,7 +15,7 @@ func TestNewHumanGateActionCrossRepo(t *testing.T) {
 	t.Run("external_repo_task_gets_guidance", func(t *testing.T) {
 		t.Parallel()
 		a := NewHumanGateAction(PhaseFive, "1", "Merge akupara-proto PR and pin preview")
-		for _, want := range []string{"cross-repository", "preview", "update-proto", "CI"} {
+		for _, want := range []string{"cross-repository", "preview", "update-proto", "CI", "Choose 'done' only after"} {
 			if !strings.Contains(a.PresentToUser, want) {
 				t.Errorf("cross-repo gate message missing %q; got:\n%s", want, a.PresentToUser)
 			}

--- a/mcp-server/internal/engine/orchestrator/actions_test.go
+++ b/mcp-server/internal/engine/orchestrator/actions_test.go
@@ -2,8 +2,37 @@ package orchestrator
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+// TestNewHumanGateActionCrossRepo verifies improvement #5: a human gate whose task
+// involves an external repository carries cross-repo guidance (PR → CI → preview pin
+// and a skill pointer), while a plain in-repo gate stays concise.
+func TestNewHumanGateActionCrossRepo(t *testing.T) {
+	t.Parallel()
+
+	t.Run("external_repo_task_gets_guidance", func(t *testing.T) {
+		t.Parallel()
+		a := NewHumanGateAction(PhaseFive, "1", "Merge akupara-proto PR and pin preview")
+		for _, want := range []string{"cross-repository", "preview", "update-proto", "CI"} {
+			if !strings.Contains(a.PresentToUser, want) {
+				t.Errorf("cross-repo gate message missing %q; got:\n%s", want, a.PresentToUser)
+			}
+		}
+	})
+
+	t.Run("in_repo_task_stays_concise", func(t *testing.T) {
+		t.Parallel()
+		a := NewHumanGateAction(PhaseFive, "2", "Rename the local handler function")
+		if strings.Contains(a.PresentToUser, "cross-repository") {
+			t.Errorf("in-repo gate should not include cross-repo guidance; got:\n%s", a.PresentToUser)
+		}
+		if !strings.Contains(a.PresentToUser, "requires human action") {
+			t.Errorf("in-repo gate missing base message; got:\n%s", a.PresentToUser)
+		}
+	})
+}
 
 func TestSkipSummaryPrefix(t *testing.T) {
 	t.Parallel()

--- a/mcp-server/internal/engine/orchestrator/actions_test.go
+++ b/mcp-server/internal/engine/orchestrator/actions_test.go
@@ -52,7 +52,7 @@ func TestNewParallelSpawnAction(t *testing.T) {
 		model      string
 		phase      string
 		inputFiles []string
-		taskIDs    []string
+		tasks      []ParallelTask
 		want       Action
 	}{
 		{
@@ -62,34 +62,48 @@ func TestNewParallelSpawnAction(t *testing.T) {
 			model:      "sonnet",
 			phase:      "phase-5",
 			inputFiles: []string{"design.md", "tasks.md"},
-			taskIDs:    []string{"1", "2"},
+			tasks: []ParallelTask{
+				{ID: "1", OutputFile: "impl-1.md"},
+				{ID: "2", OutputFile: "impl-2.md"},
+			},
 			want: Action{
-				Type:            ActionSpawnAgent,
-				Agent:           "implementer",
-				Prompt:          "implement tasks",
-				Model:           "sonnet",
-				Phase:           "phase-5",
-				InputFiles:      []string{"design.md", "tasks.md"},
+				Type:       ActionSpawnAgent,
+				Agent:      "implementer",
+				Prompt:     "implement tasks",
+				Model:      "sonnet",
+				Phase:      "phase-5",
+				InputFiles: []string{"design.md", "tasks.md"},
+				ParallelTasks: []ParallelTask{
+					{ID: "1", OutputFile: "impl-1.md"},
+					{ID: "2", OutputFile: "impl-2.md"},
+				},
 				ParallelTaskIDs: []string{"1", "2"},
 				OutputFile:      "",
 			},
 		},
 		{
-			name:       "parallel_three_tasks",
-			agent:      "implementer",
-			prompt:     "implement all",
+			name:       "parallel_reviewers_with_per_task_inputs",
+			agent:      "impl-reviewer",
+			prompt:     "review in parallel",
 			model:      "sonnet",
-			phase:      "phase-5",
-			inputFiles: []string{"design.md"},
-			taskIDs:    []string{"1", "2", "3"},
+			phase:      "phase-6",
+			inputFiles: []string{"tasks.md"},
+			tasks: []ParallelTask{
+				{ID: "1", InputFiles: []string{"impl-1.md"}, OutputFile: "review-1.md"},
+				{ID: "3", InputFiles: []string{"impl-3.md"}, OutputFile: "review-3.md"},
+			},
 			want: Action{
-				Type:            ActionSpawnAgent,
-				Agent:           "implementer",
-				Prompt:          "implement all",
-				Model:           "sonnet",
-				Phase:           "phase-5",
-				InputFiles:      []string{"design.md"},
-				ParallelTaskIDs: []string{"1", "2", "3"},
+				Type:       ActionSpawnAgent,
+				Agent:      "impl-reviewer",
+				Prompt:     "review in parallel",
+				Model:      "sonnet",
+				Phase:      "phase-6",
+				InputFiles: []string{"tasks.md"},
+				ParallelTasks: []ParallelTask{
+					{ID: "1", InputFiles: []string{"impl-1.md"}, OutputFile: "review-1.md"},
+					{ID: "3", InputFiles: []string{"impl-3.md"}, OutputFile: "review-3.md"},
+				},
+				ParallelTaskIDs: []string{"1", "3"},
 				OutputFile:      "",
 			},
 		},
@@ -99,7 +113,7 @@ func TestNewParallelSpawnAction(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := NewParallelSpawnAction(tc.agent, tc.prompt, tc.model, tc.phase, tc.inputFiles, tc.taskIDs)
+			got := NewParallelSpawnAction(tc.agent, tc.prompt, tc.model, tc.phase, tc.inputFiles, tc.tasks)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("NewParallelSpawnAction() = %+v, want %+v", got, tc.want)
 			}

--- a/mcp-server/internal/engine/orchestrator/engine.go
+++ b/mcp-server/internal/engine/orchestrator/engine.go
@@ -666,7 +666,12 @@ func (e *Engine) handlePhaseSix(st *state.State) (Action, error) {
 		// All tasks removed after init (edge case); advance — mirrors handlePhaseFive behaviour
 		return NewDoneAction(SkipSummaryPrefix+PhaseSix, ""), nil
 	}
-	// Decision 23 — Phase 6 PASS/FAIL retry
+	// Decision 23 — Phase 6 PASS/FAIL retry.
+	// needsReview accumulates tasks that have no review file yet so independent
+	// reviews can be fanned out in a single parallel batch (improvement #1) instead
+	// of being dispatched one at a time. A failing review takes priority and short-
+	// circuits to an implementer retry, matching the original sequential semantics.
+	var needsReview []string
 	for _, k := range taskKeys {
 		task := st.Tasks[k]
 
@@ -690,19 +695,14 @@ func (e *Engine) handlePhaseSix(st *state.State) (Action, error) {
 			return dispatchImplementerRetry(k, task)
 		}
 
-		// If review file doesn't exist, spawn reviewer.
+		// If review file doesn't exist, the task needs a fresh review. Collect it
+		// and continue scanning so all pending reviews can be dispatched together.
 		if _, err := os.Stat(reviewFile); err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				return Action{}, fmt.Errorf("handlePhaseSix: stat %s: %w", reviewFile, err)
 			}
-			return NewSpawnAgentAction(
-				agentImplReviewer,
-				"Review implementation for task "+k+".",
-				state.DefaultModel,
-				PhaseSix,
-				[]string{"impl-" + k + ".md", state.ArtifactTasks},
-				"review-"+k+".md",
-			), nil
+			needsReview = append(needsReview, k)
+			continue
 		}
 
 		// Review file exists but ReviewStatus not yet set — transitional state
@@ -724,10 +724,36 @@ func (e *Engine) handlePhaseSix(st *state.State) (Action, error) {
 		// pipeline_report_result so the engine never re-processes this task.
 	}
 
-	// All tasks reviewed; phase-6 is done. Return a done signal so
-	// pipeline_report_result advances to phase-7, where handlePhaseSeven
-	// dispatches the comprehensive-reviewer with the correct artifact name.
-	return NewDoneAction(SkipSummaryPrefix+PhaseSix, ""), nil
+	// Dispatch the reviews collected above. Multiple independent reviews are fanned
+	// out as a single parallel batch; pipeline_report_result already reconciles all
+	// review-*.md verdicts in one pass, so no per-task report round-trip is required.
+	switch len(needsReview) {
+	case 0:
+		// All tasks reviewed; phase-6 is done. Return a done signal so
+		// pipeline_report_result advances to phase-7, where handlePhaseSeven
+		// dispatches the comprehensive-reviewer with the correct artifact name.
+		return NewDoneAction(SkipSummaryPrefix+PhaseSix, ""), nil
+	case 1:
+		k := needsReview[0]
+		return NewSpawnAgentAction(
+			agentImplReviewer,
+			"Review implementation for task "+k+".",
+			state.DefaultModel,
+			PhaseSix,
+			[]string{"impl-" + k + ".md", state.ArtifactTasks},
+			"review-"+k+".md",
+		), nil
+	default:
+		return NewParallelSpawnAction(
+			agentImplReviewer,
+			"Review implementations in parallel — spawn one reviewer per task ID, each "+
+				"reading its impl-<id>.md and writing its verdict to review-<id>.md.",
+			state.DefaultModel,
+			PhaseSix,
+			[]string{state.ArtifactTasks},
+			needsReview,
+		), nil
+	}
 }
 
 // dispatchImplementerRetry returns an action to retry the implementer for task k,
@@ -997,6 +1023,16 @@ func ClosingRef(workspace string) string {
 // Exported so pipeline_init_with_context can derive the branch name during
 // initialisation (before Phase 5).
 func DeriveBranchName(st *state.State) string {
+	return DeriveBranchNameFromContent(st, "")
+}
+
+// DeriveBranchNameFromContent is like DeriveBranchName but picks the branch type
+// prefix (feature/fix/refactor/docs/chore) by classifying the supplied content —
+// typically the request body — so the initial branch already matches the work type
+// instead of always starting at "feature/" and being renamed after Phase 3b
+// (improvement #3). When content is empty (or classifies as a feature) the prefix
+// is "feature/". A later maybeRenameBranch can still refine the prefix from design.md.
+func DeriveBranchNameFromContent(st *state.State, content string) string {
 	name := stripDatePrefix(st.SpecName)
 	name = strings.ToLower(strings.ReplaceAll(name, " ", "-"))
 
@@ -1009,7 +1045,12 @@ func DeriveBranchName(st *state.State) string {
 		}
 	}
 
-	return "feature/" + name
+	prefix := BranchTypeFeature
+	if strings.TrimSpace(content) != "" {
+		prefix = ClassifyBranchType(content)
+	}
+
+	return prefix + "/" + name
 }
 
 // stripDatePrefix removes a leading "YYYYMMDD-" date prefix from a spec name.

--- a/mcp-server/internal/engine/orchestrator/engine.go
+++ b/mcp-server/internal/engine/orchestrator/engine.go
@@ -1121,7 +1121,10 @@ var branchTypeRules = []branchTypeRule{
 	{
 		Type: BranchTypeFix,
 		Keywords: []string{
-			"bug", "fix", "defect", "hotfix", // EN
+			// EN (whole-word matched; include common plural/inflected forms because
+			// word-boundary matching no longer catches them as substrings)
+			"bug", "bugs", "fix", "fixes", "defect", "defects",
+			"hotfix", "hotfixes", "bugfix", "bugfixes",
 			"バグ", "修正", "不具合", "障害", // JA
 			"fehler", "bugfix", // DE
 			"correctif", "bogue", // FR
@@ -1130,7 +1133,10 @@ var branchTypeRules = []branchTypeRule{
 	{
 		Type: BranchTypeRefactor,
 		Keywords: []string{
-			"refactor", "restructure", "reorganize", // EN
+			// EN
+			"refactor", "refactors", "refactoring",
+			"restructure", "restructures", "restructuring",
+			"reorganize", "reorganizes", "reorganizing",
 			"リファクタ", "再構成", "構造改善", // JA
 			"refaktorierung", "umstrukturierung", // DE
 			"refactorisation", "restructuration", // FR
@@ -1139,7 +1145,7 @@ var branchTypeRules = []branchTypeRule{
 	{
 		Type: BranchTypeDocs,
 		Keywords: []string{
-			"documentation", "readme", // EN
+			"documentation", "readme", "readmes", "docs", // EN
 			"ドキュメント", "文書", "資料", // JA
 			"dokumentation", // DE
 			// FR: "documentation" is shared with EN
@@ -1148,7 +1154,10 @@ var branchTypeRules = []branchTypeRule{
 	{
 		Type: BranchTypeChore,
 		Keywords: []string{
-			"dependency", "upgrade", "migration", "config", // EN
+			// EN — include plurals (e.g. "dependencies", which is not a substring of
+			// "dependency") so word-boundary matching still classifies them.
+			"dependency", "dependencies", "upgrade", "upgrades",
+			"migration", "migrations", "config", "configs", "configuration",
 			"依存", "アップグレード", "移行", "設定", // JA
 			"abhängigkeit", "configuration", // DE
 			"dépendance", "configuration", // FR
@@ -1162,12 +1171,61 @@ func ClassifyBranchType(content string) string {
 	lower := strings.ToLower(content)
 	for _, rule := range branchTypeRules {
 		for _, kw := range rule.Keywords {
-			if strings.Contains(lower, kw) {
+			if containsKeyword(lower, kw) {
 				return rule.Type
 			}
 		}
 	}
 	return BranchTypeFeature
+}
+
+// containsKeyword reports whether keyword occurs in text. ASCII-letter keywords must match
+// at a word boundary so "fix" does not classify "prefix"/"suffix"/"fixtures"; keywords that
+// contain non-ASCII letters (e.g. Japanese) fall back to substring matching, since CJK text
+// has no whitespace word boundaries. Both arguments are expected to be lowercased already.
+func containsKeyword(text, keyword string) bool {
+	if !isASCIIWord(keyword) {
+		return strings.Contains(text, keyword)
+	}
+	for from := 0; from+len(keyword) <= len(text); {
+		idx := strings.Index(text[from:], keyword)
+		if idx < 0 {
+			return false
+		}
+		start := from + idx
+		end := start + len(keyword)
+		beforeOK := start == 0 || !isWordByte(text[start-1])
+		afterOK := end == len(text) || !isWordByte(text[end])
+		if beforeOK && afterOK {
+			return true
+		}
+		from = start + 1
+	}
+	return false
+}
+
+// isASCIIWord reports whether s consists solely of ASCII letters, so that whole-word
+// boundary matching is meaningful. Empty or non-ASCII keywords return false.
+func isASCIIWord(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+// isWordByte reports whether b is an ASCII word character (letter, digit, or underscore).
+// Bytes >= 0x80 (UTF-8 continuation / lead bytes, e.g. a CJK char adjacent to an English
+// keyword) are not word bytes, so they count as a boundary.
+func isWordByte(b byte) bool {
+	return b == '_' ||
+		(b >= '0' && b <= '9') ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z')
 }
 
 // branchPrefix extracts the prefix before the first "/" in a branch name.

--- a/mcp-server/internal/engine/orchestrator/engine.go
+++ b/mcp-server/internal/engine/orchestrator/engine.go
@@ -635,7 +635,7 @@ func (*Engine) handlePhaseFive(st *state.State) (Action, error) {
 			state.DefaultModel,
 			PhaseFive,
 			implInputFiles,
-			parallelKeys,
+			implParallelTasks(parallelKeys),
 		), nil
 	}
 
@@ -648,6 +648,33 @@ func (*Engine) handlePhaseFive(st *state.State) (Action, error) {
 		implInputFiles,
 		"impl-"+firstKey+".md",
 	), nil
+}
+
+// implParallelTasks builds the per-task contract for a phase-5 parallel batch: each task
+// writes its own impl-<id>.md and shares the batch's input_files (the agent reads task <id>
+// from tasks.md, so no task-specific InputFiles are needed). keys must be caller-ordered.
+func implParallelTasks(keys []string) []ParallelTask {
+	tasks := make([]ParallelTask, len(keys))
+	for i, k := range keys {
+		tasks[i] = ParallelTask{ID: k, OutputFile: "impl-" + k + ".md"}
+	}
+	return tasks
+}
+
+// reviewParallelTasks builds the per-task contract for a phase-6 parallel review batch: each
+// reviewer reads its own impl-<id>.md (plus the shared tasks.md) and writes its verdict to
+// review-<id>.md. Supplying this mapping keeps the orchestrator from inferring filenames from
+// the prompt prose. keys must be caller-ordered.
+func reviewParallelTasks(keys []string) []ParallelTask {
+	tasks := make([]ParallelTask, len(keys))
+	for i, k := range keys {
+		tasks[i] = ParallelTask{
+			ID:         k,
+			InputFiles: []string{"impl-" + k + ".md"},
+			OutputFile: "review-" + k + ".md",
+		}
+	}
+	return tasks
 }
 
 // handlePhaseSix handles Phase 6 (impl reviewer) — Decision 23.
@@ -746,12 +773,12 @@ func (e *Engine) handlePhaseSix(st *state.State) (Action, error) {
 	default:
 		return NewParallelSpawnAction(
 			agentImplReviewer,
-			"Review implementations in parallel — spawn one reviewer per task ID, each "+
-				"reading its impl-<id>.md and writing its verdict to review-<id>.md.",
+			"Review implementations in parallel — one reviewer per task in parallel_tasks, "+
+				"each reading its input_files and writing its verdict to its output_file.",
 			state.DefaultModel,
 			PhaseSix,
 			[]string{state.ArtifactTasks},
-			needsReview,
+			reviewParallelTasks(needsReview),
 		), nil
 	}
 }

--- a/mcp-server/internal/engine/orchestrator/engine_test.go
+++ b/mcp-server/internal/engine/orchestrator/engine_test.go
@@ -991,6 +991,43 @@ func TestNextAction(t *testing.T) {
 			wantSummary: SkipSummaryPrefix + PhaseSix,
 		},
 
+		// ── Improvement #1: phase-6 batches independent reviews in parallel ──
+		{
+			// Two implemented, unreviewed tasks (no review-*.md yet) must be fanned
+			// out as a single parallel reviewer batch rather than one at a time.
+			name: "phase6_parallel_reviews",
+			setupSM: func(t *testing.T) *state.StateManager {
+				t.Helper()
+				return newTestStateManager(t, "phase-6", func(s *state.State) error {
+					s.Tasks = map[string]state.Task{
+						"1": {Title: "Task 1", ExecutionMode: "sequential", ImplStatus: "completed", ReviewStatus: ""},
+						"2": {Title: "Task 2", ExecutionMode: "sequential", ImplStatus: "completed", ReviewStatus: ""},
+					}
+					return nil
+				})
+			},
+			wantType:        ActionSpawnAgent,
+			wantAgent:       agentImplReviewer,
+			wantParallelIDs: []string{"1", "2"},
+		},
+
+		// ── Improvement #1: phase-6 single pending review uses a non-parallel spawn ──
+		{
+			name: "phase6_single_review",
+			setupSM: func(t *testing.T) *state.StateManager {
+				t.Helper()
+				return newTestStateManager(t, "phase-6", func(s *state.State) error {
+					s.Tasks = map[string]state.Task{
+						"1": {Title: "Task 1", ExecutionMode: "sequential", ImplStatus: "completed", ReviewStatus: ""},
+					}
+					return nil
+				})
+			},
+			wantType:        ActionSpawnAgent,
+			wantAgent:       agentImplReviewer,
+			wantParallelIDs: []string{}, // assert len == 0 (single spawn, not a fanout)
+		},
+
 		// ── Decision 23: phase-6 empty Tasks skips the phase (edge case, mirrors phase-5) ─
 		{
 			name: "phase6_empty_tasks_skips",
@@ -1371,6 +1408,34 @@ func TestDeriveBranchName(t *testing.T) {
 			got := DeriveBranchName(st)
 			if got != tt.want {
 				t.Errorf("DeriveBranchName(%q) = %q, want %q", tt.specName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveBranchNameFromContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		specName string
+		content  string
+		want     string
+	}{
+		{"empty_content_defaults_feature", "soa-1-add-thing", "", "feature/soa-1-add-thing"},
+		{"feature_content", "soa-1-add-thing", "implement a new dashboard capability", "feature/soa-1-add-thing"},
+		{"fix_content", "soa-2-login", "fix a bug where login fails", "fix/soa-2-login"},
+		{"japanese_fix_content", "soa-3-login", "ログインの不具合を修正する", "fix/soa-3-login"},
+		{"refactor_content", "soa-4-cleanup", "refactor the module structure", "refactor/soa-4-cleanup"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			st := &state.State{SpecName: tt.specName}
+			got := DeriveBranchNameFromContent(st, tt.content)
+			if got != tt.want {
+				t.Errorf("DeriveBranchNameFromContent(%q, %q) = %q, want %q", tt.specName, tt.content, got, tt.want)
 			}
 		})
 	}

--- a/mcp-server/internal/engine/orchestrator/engine_test.go
+++ b/mcp-server/internal/engine/orchestrator/engine_test.go
@@ -2440,6 +2440,17 @@ func TestClassifyBranchType(t *testing.T) {
 		{name: "case_insensitive_REFACTOR", content: "REFACTOR the service layer", want: BranchTypeRefactor},
 		{name: "case_insensitive_DOCUMENTATION", content: "DOCUMENTATION update needed", want: BranchTypeDocs},
 
+		// Word-boundary: "fix" must not be matched inside larger words (false positives)
+		{name: "boundary_prefix", content: "Add a prefix to generated identifiers", want: BranchTypeFeature},
+		{name: "boundary_suffix", content: "Support a configurable filename suffix", want: BranchTypeFeature},
+		{name: "boundary_fixtures", content: "Add test fixtures for the parser", want: BranchTypeFeature},
+		// Plurals/inflections must still classify (no false negatives from boundary matching)
+		{name: "en_bugs_plural", content: "Resolve several bugs in the importer", want: BranchTypeFix},
+		{name: "en_fixes_plural", content: "Ship fixes for the flaky tests", want: BranchTypeFix},
+		{name: "en_refactoring", content: "Refactoring the handler layer", want: BranchTypeRefactor},
+		{name: "en_dependencies_plural", content: "Bump dependencies to latest", want: BranchTypeChore},
+		{name: "en_migrations_plural", content: "Run database migrations", want: BranchTypeChore},
+
 		// Default
 		{name: "empty_input", content: "", want: BranchTypeFeature},
 		{name: "no_keywords", content: "Add new user profile page with avatar upload", want: BranchTypeFeature},

--- a/mcp-server/internal/engine/orchestrator/engine_test.go
+++ b/mcp-server/internal/engine/orchestrator/engine_test.go
@@ -290,12 +290,13 @@ type nextActionTestCase struct {
 	wantType               string
 	wantAgent              string
 	wantSummary            string
-	wantPhase              string   // non-empty: assert action.Phase equals this value
-	wantParallelIDs        []string // nil means "do not check"; empty slice means "assert len==0"
-	wantInputContains      string   // non-empty: assert InputFiles contains this value
-	wantSetupOnly          *bool    // non-nil: assert action.SetupOnly equals *wantSetupOnly
-	wantCommandContains    string   // non-empty: assert any Commands element contains this value
-	wantCommandNotContains string   // non-empty: assert no Commands element contains this value
+	wantPhase              string            // non-empty: assert action.Phase equals this value
+	wantParallelIDs        []string          // nil means "do not check"; empty slice means "assert len==0"
+	wantParallelOutputs    map[string]string // nil means "do not check"; otherwise assert ParallelTasks[id].OutputFile
+	wantInputContains      string            // non-empty: assert InputFiles contains this value
+	wantSetupOnly          *bool             // non-nil: assert action.SetupOnly equals *wantSetupOnly
+	wantCommandContains    string            // non-empty: assert any Commands element contains this value
+	wantCommandNotContains string            // non-empty: assert no Commands element contains this value
 }
 
 // defaultEng returns an Engine with stubbed readers (approve + text).
@@ -723,8 +724,9 @@ func TestNextAction(t *testing.T) {
 					return nil
 				})
 			},
-			wantType:        ActionSpawnAgent,
-			wantParallelIDs: []string{"1", "2"},
+			wantType:            ActionSpawnAgent,
+			wantParallelIDs:     []string{"1", "2"},
+			wantParallelOutputs: map[string]string{"1": "impl-1.md", "2": "impl-2.md"},
 		},
 
 		// ── Decision 22: phase-5 single parallel task dispatches via ParallelSpawnAction ──
@@ -1321,6 +1323,16 @@ func TestNextAction(t *testing.T) {
 					if !reflect.DeepEqual(action.ParallelTaskIDs, tc.wantParallelIDs) {
 						t.Errorf("ParallelTaskIDs = %v, want %v", action.ParallelTaskIDs, tc.wantParallelIDs)
 					}
+				}
+			}
+
+			if tc.wantParallelOutputs != nil {
+				got := make(map[string]string, len(action.ParallelTasks))
+				for _, pt := range action.ParallelTasks {
+					got[pt.ID] = pt.OutputFile
+				}
+				if !reflect.DeepEqual(got, tc.wantParallelOutputs) {
+					t.Errorf("ParallelTasks output_file map = %v, want %v", got, tc.wantParallelOutputs)
 				}
 			}
 

--- a/mcp-server/internal/engine/state/manager.go
+++ b/mcp-server/internal/engine/state/manager.go
@@ -1010,6 +1010,25 @@ func (m *StateManager) PhaseLog(workspace, phase string, tokens, durationMs int,
 	})
 }
 
+// SetLastDispatch records the model and setup-only flag of the action the engine just
+// dispatched, so the next pipeline_next_action call can auto-carry previous_model and
+// previous_setup_only without the orchestrator threading them by hand (improvement #9).
+func (m *StateManager) SetLastDispatch(workspace, phase, model string, setupOnly bool) error {
+	// Workspace entry-point guard.
+	if err := m.bindWorkspace(workspace); err != nil {
+		return err
+	}
+
+	return m.Update(func(s *State) error {
+		s.LastDispatch = &LastDispatch{
+			Phase:     phase,
+			Model:     model,
+			SetupOnly: setupOnly,
+		}
+		return nil
+	})
+}
+
 // PhaseStatsResult is the structured return value for PhaseStats.
 type PhaseStatsResult struct {
 	TotalTokens     int             `json:"totalTokens"`

--- a/mcp-server/internal/engine/state/state.go
+++ b/mcp-server/internal/engine/state/state.go
@@ -23,28 +23,28 @@ var ValidRevTypes = []string{RevTypeDesign, RevTypeTasks}
 
 // State mirrors the top-level state.json object written by the Go MCP server state package.
 type State struct {
-	Version                   int             `json:"version"`
-	MCPVersion                string          `json:"forge-state-mcp-version,omitempty"`
-	SpecName                  string          `json:"specName"`
-	Workspace                 string          `json:"workspace"`
-	Branch                    *string         `json:"branch"`
-	Effort                    *string         `json:"effort"`
-	FlowTemplate              *string         `json:"flowTemplate"`
-	AutoApprove               bool            `json:"autoApprove"`
-	SkipPr                    bool            `json:"skipPr"`
-	UseCurrentBranch          bool            `json:"useCurrentBranch"`
-	BranchClassified          bool            `json:"branchClassified"`
-	BranchPushed              bool            `json:"branchPushed"`
-	Debug                     bool            `json:"debug"`
-	SkippedPhases             []string        `json:"skippedPhases"`
-	CurrentPhase              string          `json:"currentPhase"`
-	CurrentPhaseStatus        string          `json:"currentPhaseStatus"`
-	CompletedPhases           []string        `json:"completedPhases"`
-	Revisions                 Revisions       `json:"revisions"`
+	Version            int       `json:"version"`
+	MCPVersion         string    `json:"forge-state-mcp-version,omitempty"`
+	SpecName           string    `json:"specName"`
+	Workspace          string    `json:"workspace"`
+	Branch             *string   `json:"branch"`
+	Effort             *string   `json:"effort"`
+	FlowTemplate       *string   `json:"flowTemplate"`
+	AutoApprove        bool      `json:"autoApprove"`
+	SkipPr             bool      `json:"skipPr"`
+	UseCurrentBranch   bool      `json:"useCurrentBranch"`
+	BranchClassified   bool      `json:"branchClassified"`
+	BranchPushed       bool      `json:"branchPushed"`
+	Debug              bool      `json:"debug"`
+	SkippedPhases      []string  `json:"skippedPhases"`
+	CurrentPhase       string    `json:"currentPhase"`
+	CurrentPhaseStatus string    `json:"currentPhaseStatus"`
+	CompletedPhases    []string  `json:"completedPhases"`
+	Revisions          Revisions `json:"revisions"`
 	// DesignReviseCapReached is set when the design REVISE cap fires.
 	// Consumed by: implementer prompt enrichment (review-design.md is added as
 	// input artifact) and analytics_pipeline_summary (to flag auto-promoted runs).
-	DesignReviseCapReached bool `json:"designReviseCapReached,omitempty"`
+	DesignReviseCapReached    bool            `json:"designReviseCapReached,omitempty"`
 	CheckpointRevisionPending map[string]bool `json:"checkpointRevisionPending"`
 	NeedsBatchCommit          bool            `json:"needsBatchCommit"`
 	PendingHumanGate          *string         `json:"pendingHumanGate,omitempty"`
@@ -52,6 +52,19 @@ type State struct {
 	PhaseLog                  []PhaseLogEntry `json:"phaseLog"`
 	Timestamps                Timestamps      `json:"timestamps"`
 	Error                     *PhaseError     `json:"error"`
+	// LastDispatch records the model and setup-only flag of the most recent agent/exec
+	// action the engine returned to the orchestrator. The next pipeline_next_action call
+	// auto-carries these into the phase-log report so the orchestrator no longer has to
+	// thread previous_model / previous_setup_only by hand (improvement #9). Tokens and
+	// duration still come from the orchestrator — only it observes the subagent's usage.
+	LastDispatch *LastDispatch `json:"lastDispatch,omitempty"`
+}
+
+// LastDispatch captures the engine-authoritative metadata of the last dispatched action.
+type LastDispatch struct {
+	Phase     string `json:"phase"`
+	Model     string `json:"model"`
+	SetupOnly bool   `json:"setupOnly"`
 }
 
 // Revisions holds counters for design/task review revision cycles.

--- a/mcp-server/internal/handler/tools/display.go
+++ b/mcp-server/internal/handler/tools/display.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/orchestrator"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/analytics"
 )
 
 // buildSpawnMessage returns the progress line to display before spawning an agent.
@@ -29,6 +30,18 @@ func buildSpawnMessage(action orchestrator.Action) string {
 func buildCompleteMessage(tokensUsed, durationMs int) string {
 	return fmt.Sprintf("  ✓ Complete  ·  %s tokens · %s",
 		formatTokens(tokensUsed), formatDuration(durationMs))
+}
+
+// formatCheckpointCostLine returns a one-line running-cost summary for display at a
+// human checkpoint, e.g. "  💰 So far: 1,234,567 tokens · ~$7.41 · 6 phases · 2 retries".
+// Returns "" for a nil summary or a fresh pipeline that has logged no work yet, so the
+// line is only shown once there is something meaningful to report (improvement #8).
+func formatCheckpointCostLine(s *analytics.PipelineSummary) string {
+	if s == nil || s.TotalTokens == 0 {
+		return ""
+	}
+	return fmt.Sprintf("  💰 So far: %s tokens · ~$%.2f · %d phases · %d retries",
+		formatTokens(s.TotalTokens), s.EstimatedCostUSD, s.PhasesExecuted, s.Retries)
 }
 
 // phaseDisplayLabel builds a human-readable label for a phase ID.

--- a/mcp-server/internal/handler/tools/display.go
+++ b/mcp-server/internal/handler/tools/display.go
@@ -44,6 +44,25 @@ func formatCheckpointCostLine(s *analytics.PipelineSummary) string {
 		formatTokens(s.TotalTokens), s.EstimatedCostUSD, s.PhasesExecuted, s.Retries)
 }
 
+// formatEstimateLine returns a one-line, pre-formatted upfront cost/token forecast for
+// the detected effort, e.g.
+// "  📊 Estimate (effort=L, 4 past run(s)): ~1,234,567 tokens / ~$7.41 (P50) · up to ~2,345,678 tokens / ~$14.08 (P90)".
+// Returns "" when no estimate is available (nil) or there is no history (sample_size 0).
+// The orchestrator displays this verbatim, so the P50/P90 figures are formatted here in
+// the server rather than reconstructed by the LLM from the raw estimate struct — keeping
+// the presentation deterministic (improvement #8).
+func formatEstimateLine(effort string, est *analytics.EstimateResult) string {
+	if est == nil || est.SampleSize == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"  📊 Estimate (effort=%s, %d past run(s)): ~%s tokens / ~$%.2f (P50) · up to ~%s tokens / ~$%.2f (P90)",
+		effort, est.SampleSize,
+		formatTokens(int(est.Tokens.P50)), est.CostUSD.P50,
+		formatTokens(int(est.Tokens.P90)), est.CostUSD.P90,
+	)
+}
+
 // phaseDisplayLabel builds a human-readable label for a phase ID.
 // For phase-N IDs returns "Phase N — Label" when a label exists in the registry,
 // or just "Phase N" when the registry falls back to the ID itself.

--- a/mcp-server/internal/handler/tools/display_test.go
+++ b/mcp-server/internal/handler/tools/display_test.go
@@ -1,10 +1,46 @@
 package tools
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/orchestrator"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/analytics"
 )
+
+func TestFormatCheckpointCostLine(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_summary", func(t *testing.T) {
+		t.Parallel()
+		if got := formatCheckpointCostLine(nil); got != "" {
+			t.Errorf("nil summary: want empty, got %q", got)
+		}
+	})
+
+	t.Run("zero_tokens_suppressed", func(t *testing.T) {
+		t.Parallel()
+		got := formatCheckpointCostLine(&analytics.PipelineSummary{TotalTokens: 0})
+		if got != "" {
+			t.Errorf("fresh pipeline (0 tokens): want empty, got %q", got)
+		}
+	})
+
+	t.Run("formats_running_cost", func(t *testing.T) {
+		t.Parallel()
+		got := formatCheckpointCostLine(&analytics.PipelineSummary{
+			TotalTokens:      1234567,
+			EstimatedCostUSD: 7.41,
+			PhasesExecuted:   6,
+			Retries:          2,
+		})
+		for _, want := range []string{"1,234,567 tokens", "$7.41", "6 phases", "2 retries"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("cost line %q missing %q", got, want)
+			}
+		}
+	})
+}
 
 func TestBuildSpawnMessage(t *testing.T) {
 	t.Parallel()

--- a/mcp-server/internal/handler/tools/display_test.go
+++ b/mcp-server/internal/handler/tools/display_test.go
@@ -101,7 +101,11 @@ func TestBuildSpawnMessage(t *testing.T) {
 		{
 			name: "parallel_phase5",
 			action: orchestrator.NewParallelSpawnAction("implementer", "", "", "phase-5", nil,
-				[]string{"1", "2", "3"}),
+				[]orchestrator.ParallelTask{
+					{ID: "1", OutputFile: "impl-1.md"},
+					{ID: "2", OutputFile: "impl-2.md"},
+					{ID: "3", OutputFile: "impl-3.md"},
+				}),
 			want: "▶ Phase 5 — Implementation  ·  spawning implementer  (parallel · 3 tasks)…",
 		},
 		{

--- a/mcp-server/internal/handler/tools/display_test.go
+++ b/mcp-server/internal/handler/tools/display_test.go
@@ -42,6 +42,39 @@ func TestFormatCheckpointCostLine(t *testing.T) {
 	})
 }
 
+func TestFormatEstimateLine(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_estimate", func(t *testing.T) {
+		t.Parallel()
+		if got := formatEstimateLine("L", nil); got != "" {
+			t.Errorf("nil estimate: want empty, got %q", got)
+		}
+	})
+
+	t.Run("zero_sample_suppressed", func(t *testing.T) {
+		t.Parallel()
+		got := formatEstimateLine("L", &analytics.EstimateResult{SampleSize: 0})
+		if got != "" {
+			t.Errorf("no history (sample_size 0): want empty, got %q", got)
+		}
+	})
+
+	t.Run("formats_p50_p90", func(t *testing.T) {
+		t.Parallel()
+		got := formatEstimateLine("L", &analytics.EstimateResult{
+			SampleSize: 4,
+			Tokens:     analytics.Percentiles{P50: 1234567, P90: 2345678},
+			CostUSD:    analytics.Percentiles{P50: 7.41, P90: 14.08},
+		})
+		for _, want := range []string{"effort=L", "4 past run", "1,234,567 tokens", "$7.41", "2,345,678 tokens", "$14.08", "P50", "P90"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("estimate line %q missing %q", got, want)
+			}
+		}
+	})
+}
+
 func TestBuildSpawnMessage(t *testing.T) {
 	t.Parallel()
 

--- a/mcp-server/internal/handler/tools/findings_filter_test.go
+++ b/mcp-server/internal/handler/tools/findings_filter_test.go
@@ -1,0 +1,78 @@
+package tools
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/state"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/history"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/prompt"
+)
+
+func patternTitles(entries []history.PatternEntry) []string {
+	out := make([]string, len(entries))
+	for i, e := range entries {
+		out[i] = e.Pattern
+	}
+	return out
+}
+
+// TestFilterFindingsForTask verifies improvement #2: a per-task impl-reviewer only
+// receives findings relevant to the task under review.
+func TestFilterFindingsForTask(t *testing.T) {
+	t.Parallel()
+
+	sqlFinding := history.PatternEntry{Pattern: "distinct order sql query 42p10", Severity: "CRITICAL", Category: "performance"}
+	adapterFinding := history.PatternEntry{Pattern: "adapter user mapping incorrect", Severity: "MINOR", Category: "naming_convention"}
+
+	ctxFor := func() prompt.HistoryContext {
+		return prompt.HistoryContext{
+			AllPatterns:      []history.PatternEntry{sqlFinding, adapterFinding},
+			CriticalPatterns: []history.PatternEntry{sqlFinding},
+		}
+	}
+
+	t.Run("frontend_task_drops_sql_finding", func(t *testing.T) {
+		t.Parallel()
+		st := &state.State{Tasks: map[string]state.Task{
+			"14": {Title: "FE user adapter", Files: []string{"frontend/app/adapters/user.ts"}},
+		}}
+		got := filterFindingsForTask(st, "14", ctxFor())
+		titles := patternTitles(got.AllPatterns)
+		if slices.Contains(titles, sqlFinding.Pattern) {
+			t.Errorf("SQL finding should be dropped for a frontend task; got %v", titles)
+		}
+		if !slices.Contains(titles, adapterFinding.Pattern) {
+			t.Errorf("adapter finding should be kept for the FE adapter task; got %v", titles)
+		}
+	})
+
+	t.Run("sql_task_keeps_sql_finding", func(t *testing.T) {
+		t.Parallel()
+		st := &state.State{Tasks: map[string]state.Task{
+			"13": {Title: "deal SQL aggregation", Files: []string{"backend/query/deal.sql"}},
+		}}
+		got := filterFindingsForTask(st, "13", ctxFor())
+		if !slices.Contains(patternTitles(got.AllPatterns), sqlFinding.Pattern) {
+			t.Errorf("SQL finding should be kept for a SQL task; got %v", patternTitles(got.AllPatterns))
+		}
+	})
+
+	t.Run("fails_open_when_task_has_no_scope", func(t *testing.T) {
+		t.Parallel()
+		st := &state.State{Tasks: map[string]state.Task{"5": {Title: "", Files: nil}}}
+		got := filterFindingsForTask(st, "5", ctxFor())
+		if len(got.AllPatterns) != 2 {
+			t.Errorf("scopeless task must fail open (keep all findings); got %d", len(got.AllPatterns))
+		}
+	})
+
+	t.Run("fails_open_when_task_unknown", func(t *testing.T) {
+		t.Parallel()
+		st := &state.State{Tasks: map[string]state.Task{}}
+		got := filterFindingsForTask(st, "99", ctxFor())
+		if len(got.AllPatterns) != 2 {
+			t.Errorf("unknown task must fail open; got %d", len(got.AllPatterns))
+		}
+	})
+}

--- a/mcp-server/internal/handler/tools/markdownlint_ignore.go
+++ b/mcp-server/internal/handler/tools/markdownlint_ignore.go
@@ -1,0 +1,64 @@
+// markdownlint ignore management for forge spec artifacts.
+
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// markdownlintIgnoreEntry is the pattern forge adds so host-project markdownlint
+// runs skip the internal spec artifacts (request.md, design.md, tasks.md, impl-*.md,
+// summary.md, review-*.md) that forge writes under .specs/.
+const markdownlintIgnoreEntry = ".specs/"
+
+// markdownlintIgnoreHeader documents the generated entry so a human editing the file
+// understands why it is there.
+const markdownlintIgnoreHeader = "# Added by claude-forge: internal spec artifacts are not product docs."
+
+// ensureMarkdownlintIgnore writes or updates a .markdownlintignore at the repo root so
+// that forge's internal spec artifacts under .specs/ do not generate markdownlint noise
+// (MD032/MD036/MD034 etc.) in the host project (improvement #10).
+//
+// It is best-effort and idempotent:
+//   - only acts on the canonical .specs/<spec-name>/ workspace layout (flat/test layouts
+//     are skipped so no file is created in unexpected locations);
+//   - if .markdownlintignore is absent it is created with the .specs/ entry;
+//   - if it exists, the entry is appended only when no equivalent .specs ignore is present,
+//     preserving any user-authored content;
+//   - all I/O errors are swallowed: failing to write a lint-ignore must never break init.
+func ensureMarkdownlintIgnore(workspace string) {
+	if filepath.Base(filepath.Dir(workspace)) != ".specs" {
+		return // flat layout (e.g. test fixtures) — nothing to anchor the repo root on.
+	}
+	repoRoot := filepath.Dir(filepath.Dir(workspace))
+	ignorePath := filepath.Join(repoRoot, ".markdownlintignore")
+
+	data, err := os.ReadFile(ignorePath)
+	switch {
+	case err == nil:
+		if markdownlintIgnoreCoversSpecs(string(data)) {
+			return
+		}
+		updated := strings.TrimRight(string(data), "\n") + "\n" + markdownlintIgnoreEntry + "\n"
+		_ = os.WriteFile(ignorePath, []byte(updated), 0o600) //nolint:gosec // fixed repo-root .markdownlintignore path, not user input
+	case os.IsNotExist(err):
+		content := markdownlintIgnoreHeader + "\n" + markdownlintIgnoreEntry + "\n"
+		_ = os.WriteFile(ignorePath, []byte(content), 0o600)
+	default:
+		// Unreadable for some other reason — leave it untouched rather than clobber.
+	}
+}
+
+// markdownlintIgnoreCoversSpecs reports whether the given .markdownlintignore content
+// already ignores the .specs directory in any of its common spellings.
+func markdownlintIgnoreCoversSpecs(content string) bool {
+	for line := range strings.SplitSeq(content, "\n") {
+		switch strings.TrimRight(strings.TrimSpace(line), "/") {
+		case ".specs", ".specs/**", "/.specs":
+			return true
+		}
+	}
+	return false
+}

--- a/mcp-server/internal/handler/tools/markdownlint_ignore.go
+++ b/mcp-server/internal/handler/tools/markdownlint_ignore.go
@@ -42,10 +42,10 @@ func ensureMarkdownlintIgnore(workspace string) {
 			return
 		}
 		updated := strings.TrimRight(string(data), "\n") + "\n" + markdownlintIgnoreEntry + "\n"
-		_ = os.WriteFile(ignorePath, []byte(updated), 0o600) //nolint:gosec // fixed repo-root .markdownlintignore path, not user input
+		_ = os.WriteFile(ignorePath, []byte(updated), 0o644) //nolint:gosec // shared repo-root config must be world-readable; fixed path, not user input
 	case os.IsNotExist(err):
 		content := markdownlintIgnoreHeader + "\n" + markdownlintIgnoreEntry + "\n"
-		_ = os.WriteFile(ignorePath, []byte(content), 0o600)
+		_ = os.WriteFile(ignorePath, []byte(content), 0o644) //nolint:gosec // shared repo-root config must be world-readable; fixed path, not user input
 	default:
 		// Unreadable for some other reason — leave it untouched rather than clobber.
 	}

--- a/mcp-server/internal/handler/tools/markdownlint_ignore_test.go
+++ b/mcp-server/internal/handler/tools/markdownlint_ignore_test.go
@@ -1,0 +1,93 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newSpecsWorkspace creates a repo-root/.specs/<spec> layout under t.TempDir and
+// returns (repoRoot, workspace).
+func newSpecsWorkspace(t *testing.T) (string, string) {
+	t.Helper()
+	repoRoot := t.TempDir()
+	workspace := filepath.Join(repoRoot, ".specs", "20260601-some-spec")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	return repoRoot, workspace
+}
+
+func TestEnsureMarkdownlintIgnoreCreatesFile(t *testing.T) {
+	t.Parallel()
+	repoRoot, workspace := newSpecsWorkspace(t)
+
+	ensureMarkdownlintIgnore(workspace)
+
+	data, err := os.ReadFile(filepath.Join(repoRoot, ".markdownlintignore"))
+	if err != nil {
+		t.Fatalf("expected .markdownlintignore to be created: %v", err)
+	}
+	if !markdownlintIgnoreCoversSpecs(string(data)) {
+		t.Errorf(".markdownlintignore does not cover .specs; content:\n%s", data)
+	}
+}
+
+func TestEnsureMarkdownlintIgnoreAppendsToExisting(t *testing.T) {
+	t.Parallel()
+	repoRoot, workspace := newSpecsWorkspace(t)
+	ignorePath := filepath.Join(repoRoot, ".markdownlintignore")
+	existing := "node_modules/\nCHANGELOG.md\n"
+	if err := os.WriteFile(ignorePath, []byte(existing), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	ensureMarkdownlintIgnore(workspace)
+
+	data, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(data)
+	if !markdownlintIgnoreCoversSpecs(got) {
+		t.Errorf("expected .specs entry to be appended; content:\n%s", got)
+	}
+	// Pre-existing user content must be preserved.
+	for _, want := range []string{"node_modules/", "CHANGELOG.md"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("existing entry %q was lost; content:\n%s", want, got)
+		}
+	}
+}
+
+func TestEnsureMarkdownlintIgnoreIdempotent(t *testing.T) {
+	t.Parallel()
+	repoRoot, workspace := newSpecsWorkspace(t)
+	ignorePath := filepath.Join(repoRoot, ".markdownlintignore")
+
+	ensureMarkdownlintIgnore(workspace)
+	first, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	ensureMarkdownlintIgnore(workspace)
+	second, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("second call changed the file:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+func TestEnsureMarkdownlintIgnoreSkipsFlatLayout(t *testing.T) {
+	t.Parallel()
+	// Flat layout: workspace is a bare temp dir not under .specs/.
+	flat := t.TempDir()
+	ensureMarkdownlintIgnore(flat)
+	// No .markdownlintignore should be created next to or above a flat workspace.
+	if _, err := os.Stat(filepath.Join(filepath.Dir(flat), ".markdownlintignore")); err == nil {
+		t.Errorf("flat layout should not create a .markdownlintignore")
+	}
+}

--- a/mcp-server/internal/handler/tools/markdownlint_ignore_test.go
+++ b/mcp-server/internal/handler/tools/markdownlint_ignore_test.go
@@ -25,12 +25,22 @@ func TestEnsureMarkdownlintIgnoreCreatesFile(t *testing.T) {
 
 	ensureMarkdownlintIgnore(workspace)
 
-	data, err := os.ReadFile(filepath.Join(repoRoot, ".markdownlintignore"))
+	ignorePath := filepath.Join(repoRoot, ".markdownlintignore")
+	data, err := os.ReadFile(ignorePath)
 	if err != nil {
 		t.Fatalf("expected .markdownlintignore to be created: %v", err)
 	}
 	if !markdownlintIgnoreCoversSpecs(string(data)) {
 		t.Errorf(".markdownlintignore does not cover .specs; content:\n%s", data)
+	}
+	// Shared repo-root config must be world-readable (0o644), not owner-only (0o600),
+	// so other local users / containers / CI runners can read it.
+	info, err := os.Stat(ignorePath)
+	if err != nil {
+		t.Fatalf("stat .markdownlintignore: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf(".markdownlintignore perm = %o, want 0o644", perm)
 	}
 }
 

--- a/mcp-server/internal/handler/tools/pipeline_init_with_context.go
+++ b/mcp-server/internal/handler/tools/pipeline_init_with_context.go
@@ -74,7 +74,14 @@ type UserConfirmationPrompt struct {
 	// derived from past completed pipelines of the same effort. Present only when
 	// historical data exists (sample_size > 0), so the user can gauge how heavy the
 	// run will be before approving (improvement #8). Nil when no history is available.
+	// This raw struct is retained for the Dashboard / programmatic consumers; the
+	// orchestrator should display EstimateDisplay verbatim rather than re-formatting it.
 	Estimate *analytics.EstimateResult `json:"estimate,omitempty"`
+	// EstimateDisplay is the pre-formatted, user-facing one-line forecast the orchestrator
+	// outputs verbatim at effort selection. Empty when no history is available. Formatting
+	// lives in the server (formatEstimateLine) so the P50/P90 presentation is deterministic
+	// instead of reconstructed by the LLM from the raw Estimate struct (improvement #8).
+	EstimateDisplay string `json:"estimate_display,omitempty"`
 }
 
 // pipelineFlags holds parsed flag fields from the flags parameter.
@@ -260,15 +267,12 @@ func buildUserConfirmationPrompt(workspace string, extCtx externalContext, flags
 	// Attach an upfront cost/token estimate for the detected effort so the user knows
 	// how heavy the run will be before approving (improvement #8). Only shown when
 	// historical data exists; failures are swallowed so estimation never blocks init.
+	// The user-facing figures are pre-formatted into EstimateDisplay (verbatim) rather
+	// than appended to the procedural Message, so the LLM never reconstructs them.
 	var estimate *analytics.EstimateResult
 	if est != nil {
 		if er, eErr := est.Estimate(effort); eErr == nil && er.SampleSize > 0 {
 			estimate = er
-			message += fmt.Sprintf(
-				" Estimated cost for effort=%q (from %d past run(s)): ~%.0f tokens / ~$%.2f at P50, "+
-					"up to ~%.0f tokens / ~$%.2f at P90.",
-				effort, er.SampleSize, er.Tokens.P50, er.CostUSD.P50, er.Tokens.P90, er.CostUSD.P90,
-			)
 		}
 	}
 
@@ -280,6 +284,7 @@ func buildUserConfirmationPrompt(workspace string, extCtx externalContext, flags
 		EnrichedRequestBody: echoBody,
 		Message:             message,
 		Estimate:            estimate,
+		EstimateDisplay:     formatEstimateLine(effort, estimate),
 	}
 
 	result := PipelineInitWithContextResult{

--- a/mcp-server/internal/handler/tools/pipeline_init_with_context.go
+++ b/mcp-server/internal/handler/tools/pipeline_init_with_context.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/orchestrator"
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/sourcetype"
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/state"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/analytics"
 	"github.com/hiromaily/claude-forge/mcp-server/pkg/events"
 	"github.com/hiromaily/claude-forge/mcp-server/pkg/maputil"
 )
@@ -69,6 +70,11 @@ type UserConfirmationPrompt struct {
 	IsMainBranch        bool                    `json:"is_main_branch"`
 	Message             string                  `json:"message"`
 	EnrichedRequestBody string                  `json:"enriched_request_body,omitempty"`
+	// Estimate is a P50/P90 cost/token/duration forecast for the detected effort,
+	// derived from past completed pipelines of the same effort. Present only when
+	// historical data exists (sample_size > 0), so the user can gauge how heavy the
+	// run will be before approving (improvement #8). Nil when no history is available.
+	Estimate *analytics.EstimateResult `json:"estimate,omitempty"`
 }
 
 // pipelineFlags holds parsed flag fields from the flags parameter.
@@ -169,10 +175,15 @@ func PipelineInitWithContextHandler(sm *state.StateManager, bus *events.EventBus
 			return errorf("discussion_answers and user_confirmation must not both be present")
 		}
 
+		// Estimator forecasts run cost from past completed pipelines of the same effort.
+		// Built from the global specs dir; nil-safe and degrades to no estimate when no
+		// history exists (improvement #8).
+		est := analytics.NewEstimator(sm.SpecsDir())
+
 		switch {
 		case discussionAnswers != "":
 			// Discussion call: build enriched body, return needs_user_confirmation.
-			return handleDiscussionCall(workspace, extCtx, flags, discussionAnswers)
+			return handleDiscussionCall(workspace, extCtx, flags, discussionAnswers, est)
 		case hasConfirmation && ucRaw != nil:
 			// Confirmation call: validate effort, initialise workspace, write files.
 			uc, err := parseUserConfirmation(ucRaw)
@@ -182,14 +193,14 @@ func PipelineInitWithContextHandler(sm *state.StateManager, bus *events.EventBus
 			return handleSecondCall(sm, bus, workspace, extCtx, flags, uc)
 		default:
 			// First call: detect effort, return needs_user_confirmation (or needs_discussion).
-			return handleFirstCall(workspace, extCtx, flags)
+			return handleFirstCall(workspace, extCtx, flags, est)
 		}
 	}
 }
 
 // ---------- first call ----------
 
-func handleFirstCall(workspace string, extCtx externalContext, flags pipelineFlags) (*mcp.CallToolResult, error) {
+func handleFirstCall(workspace string, extCtx externalContext, flags pipelineFlags, est *analytics.Estimator) (*mcp.CallToolResult, error) {
 	if flags.Discuss && !flags.Auto && extCtx.IsTextSource() {
 		result := PipelineInitWithContextResult{
 			NeedsDiscussion: &DiscussionPrompt{
@@ -202,12 +213,13 @@ func handleFirstCall(workspace string, extCtx externalContext, flags pipelineFla
 	}
 
 	// Standard path: detect effort and return needs_user_confirmation.
-	return buildUserConfirmationPrompt(workspace, extCtx, flags, "")
+	return buildUserConfirmationPrompt(workspace, extCtx, flags, "", est)
 }
 
 // buildUserConfirmationPrompt constructs a needs_user_confirmation response.
 // enrichedBody is set when called from handleDiscussionCall; "" otherwise.
-func buildUserConfirmationPrompt(workspace string, extCtx externalContext, flags pipelineFlags, enrichedBody string) (*mcp.CallToolResult, error) {
+// est (nil-safe) provides an upfront cost/token estimate for the detected effort.
+func buildUserConfirmationPrompt(workspace string, extCtx externalContext, flags pipelineFlags, enrichedBody string, est *analytics.Estimator) (*mcp.CallToolResult, error) {
 	// Detect effort.
 	combinedText := strings.TrimSpace(extCtx.Fields.CombinedText() + " " + extCtx.TaskText)
 	effort := orchestrator.DetectEffort(flags.EffortOverride, extCtx.Fields.StoryPoints, combinedText)
@@ -230,6 +242,35 @@ func buildUserConfirmationPrompt(workspace string, extCtx externalContext, flags
 	if echoBody == "" {
 		echoBody = extCtx.TaskText
 	}
+	// For external issue sources (Linear/Jira/GitHub), the orchestrator may not re-send
+	// external_context on the confirmation call. Echo the issue body (title + description)
+	// here so the requirements survive the round-trip and land in request.md (improvement #4).
+	if echoBody == "" && !extCtx.Fields.IsEmpty() {
+		echoBody = strings.TrimSpace(extCtx.Fields.Title + "\n\n" + extCtx.Fields.Body)
+	}
+
+	message := fmt.Sprintf(
+		"Detected effort=%q. Current branch=%q (is_main=%v). "+
+			"Please confirm by calling pipeline_init_with_context again with "+
+			"user_confirmation={effort:..., use_current_branch:...}. "+
+			"Available effort options: S (light flow), M (standard flow), L (full flow).",
+		effort, currentBranch, isMain,
+	)
+
+	// Attach an upfront cost/token estimate for the detected effort so the user knows
+	// how heavy the run will be before approving (improvement #8). Only shown when
+	// historical data exists; failures are swallowed so estimation never blocks init.
+	var estimate *analytics.EstimateResult
+	if est != nil {
+		if er, eErr := est.Estimate(effort); eErr == nil && er.SampleSize > 0 {
+			estimate = er
+			message += fmt.Sprintf(
+				" Estimated cost for effort=%q (from %d past run(s)): ~%.0f tokens / ~$%.2f at P50, "+
+					"up to ~%.0f tokens / ~$%.2f at P90.",
+				effort, er.SampleSize, er.Tokens.P50, er.CostUSD.P50, er.Tokens.P90, er.CostUSD.P90,
+			)
+		}
+	}
 
 	nuc := &UserConfirmationPrompt{
 		DetectedEffort:      effort,
@@ -237,13 +278,8 @@ func buildUserConfirmationPrompt(workspace string, extCtx externalContext, flags
 		CurrentBranch:       currentBranch,
 		IsMainBranch:        isMain,
 		EnrichedRequestBody: echoBody,
-		Message: fmt.Sprintf(
-			"Detected effort=%q. Current branch=%q (is_main=%v). "+
-				"Please confirm by calling pipeline_init_with_context again with "+
-				"user_confirmation={effort:..., use_current_branch:...}. "+
-				"Available effort options: S (light flow), M (standard flow), L (full flow).",
-			effort, currentBranch, isMain,
-		),
+		Message:             message,
+		Estimate:            estimate,
 	}
 
 	result := PipelineInitWithContextResult{
@@ -263,9 +299,10 @@ func handleDiscussionCall(
 	extCtx externalContext,
 	flags pipelineFlags,
 	discussionAnswers string,
+	est *analytics.Estimator,
 ) (*mcp.CallToolResult, error) {
 	enrichedBody := buildEnrichedRequestBody(extCtx.TaskText, discussionAnswers)
-	return buildUserConfirmationPrompt(workspace, extCtx, flags, enrichedBody)
+	return buildUserConfirmationPrompt(workspace, extCtx, flags, enrichedBody, est)
 }
 
 // ---------- second call ----------
@@ -309,7 +346,18 @@ func handleSecondCall(
 		branchName = flags.CurrentBranch
 	} else {
 		st := &state.State{SpecName: specName}
-		branchName = orchestrator.DeriveBranchName(st)
+		// Classify the initial branch type from the request content (issue body / task
+		// text) so a new branch starts as feature/fix/refactor/etc. rather than always
+		// feature/ (improvement #3). maybeRenameBranch may still refine it from design.md.
+		// specName (the slug) is intentionally excluded: it is a terse, request-derived
+		// slug whose substrings ("prefix" → fix, "migration" → chore) would misclassify;
+		// the request body is the authoritative signal, and empty content falls back to feature.
+		classifyText := strings.TrimSpace(strings.Join([]string{
+			uc.EnrichedRequestBody,
+			extCtx.Fields.CombinedText(),
+			extCtx.TaskText,
+		}, " "))
+		branchName = orchestrator.DeriveBranchNameFromContent(st, classifyText)
 		createBranch = true
 	}
 

--- a/mcp-server/internal/handler/tools/pipeline_init_with_context_test.go
+++ b/mcp-server/internal/handler/tools/pipeline_init_with_context_test.go
@@ -835,6 +835,8 @@ func TestSourceIDPrependedToWorkspaceSlug(t *testing.T) {
 		wantBranch   string
 	}{
 		{
+			// Branch type is classified from the request content at init (improvement #3):
+			// "Fix auth timeout" / "fix-auth-timeout" → fix/ rather than the old always-feature/.
 			name:     "github_issue_with_slug",
 			sourceID: "42",
 			slug:     "fix-auth-timeout",
@@ -843,7 +845,7 @@ func TestSourceIDPrependedToWorkspaceSlug(t *testing.T) {
 				"github_body":  "requests timeout",
 			},
 			wantSpecName: "42-fix-auth-timeout",
-			wantBranch:   "feature/42-fix-auth-timeout",
+			wantBranch:   "fix/42-fix-auth-timeout",
 		},
 		{
 			name:     "jira_issue_with_slug",
@@ -1208,6 +1210,80 @@ func TestTextSourceRequestMDContainsTaskText(t *testing.T) {
 	contentStr := string(content)
 	if !strings.Contains(contentStr, taskText) {
 		t.Errorf("request.md body is missing task text %q; content:\n%s", taskText, contentStr)
+	}
+}
+
+// TestURLSourceRequestMDPersistsExternalBody reproduces improvement #4: when an
+// external issue (e.g. Linear) is the source and the orchestrator does NOT re-send
+// external_context on the confirmation call (only echoing enriched_request_body),
+// the issue body must still be persisted into request.md. The first call must echo
+// the external fields' body into enriched_request_body so it survives the round-trip.
+func TestURLSourceRequestMDPersistsExternalBody(t *testing.T) {
+	t.Parallel()
+
+	const (
+		issueTitle = "Deal risk dashboard production"
+		issueBody  = "FR-1: aggregate deal risk by stage. FR-2: surface alerts on the home dashboard."
+	)
+
+	dir := t.TempDir()
+	sm := newPIWCSM()
+	h := PipelineInitWithContextHandler(sm, events.NewEventBus())
+
+	// First call: Linear source, external_context present, no user_confirmation.
+	res1 := callTool(t, h, map[string]any{
+		"workspace":  dir,
+		"source_id":  "DEA-676",
+		"source_url": "https://linear.app/acme/issue/DEA-676/deal-risk-dashboard",
+		"external_context": map[string]any{
+			"linear_title":       issueTitle,
+			"linear_description": issueBody,
+		},
+		"flags": map[string]any{},
+	})
+	if res1.IsError {
+		t.Fatalf("first call returned MCP error: %v", textContent(res1))
+	}
+	result1 := parsePIWCResult(t, textContent(res1))
+	if result1.NeedsUserConfirmation == nil {
+		t.Fatalf("first call: expected needs_user_confirmation, got nil")
+	}
+	// enriched_request_body must carry the external issue body so the orchestrator
+	// can echo it back even when external_context is not re-sent.
+	nuc := result1.NeedsUserConfirmation
+	if !strings.Contains(nuc.EnrichedRequestBody, issueBody) {
+		t.Fatalf("first call: enriched_request_body = %q, want it to contain the issue body %q", nuc.EnrichedRequestBody, issueBody)
+	}
+
+	// Second call: orchestrator echoes enriched_request_body but does NOT re-send
+	// external_context — the exact failure scenario from improvement #4.
+	res2 := callTool(t, h, map[string]any{
+		"workspace":  dir,
+		"source_id":  "DEA-676",
+		"source_url": "https://linear.app/acme/issue/DEA-676/deal-risk-dashboard",
+		"flags":      map[string]any{},
+		"user_confirmation": map[string]any{
+			"effort":                "L",
+			"use_current_branch":    true,
+			"enriched_request_body": nuc.EnrichedRequestBody,
+		},
+	})
+	if res2.IsError {
+		t.Fatalf("second call returned MCP error: %v", textContent(res2))
+	}
+	result2 := parsePIWCResult(t, textContent(res2))
+	if !result2.Ready {
+		t.Fatalf("second call: ready = false, want true")
+	}
+
+	reqPath := filepath.Join(result2.Workspace, "request.md")
+	content, err := os.ReadFile(reqPath)
+	if err != nil {
+		t.Fatalf("ReadFile request.md: %v", err)
+	}
+	contentStr := string(content)
+	if !strings.Contains(contentStr, issueBody) {
+		t.Errorf("request.md body is missing external issue body %q; content:\n%s", issueBody, contentStr)
 	}
 }
 

--- a/mcp-server/internal/handler/tools/pipeline_integration_test.go
+++ b/mcp-server/internal/handler/tools/pipeline_integration_test.go
@@ -404,6 +404,77 @@ func TestDiscussModeEndToEnd(t *testing.T) {
 // After the second call (with previous_tokens set), P5 reports phase-1, advances to
 // phase-2, then the P1 skip loop absorbs all remaining skipped phases and returns
 // ActionDone (pipeline completed).
+// TestIntegration_P9_AutoCarryModel verifies improvement #9: after the engine dispatches
+// an agent (recording its model in LastDispatch), the next pipeline_next_action call can
+// omit previous_model and the engine auto-carries the dispatched model into the phase-log,
+// so the orchestrator no longer has to thread it by hand.
+func TestIntegration_P9_AutoCarryModel(t *testing.T) {
+	t.Parallel()
+
+	workspace, sm := initWorkspaceForNextAction(t, "phase-1", func(s *state.State) error {
+		// Skip phase-2 so phase-1 dispatches the combined analyst-investigator and
+		// produces analysis.md (the artifact P5 validates).
+		s.SkippedPhases = []string{state.PhaseTwo}
+		return nil
+	})
+
+	kb := history.NewKnowledgeBase("")
+	eng := orchestrator.NewEngine("", "")
+	handler := PipelineNextActionHandler(sm, events.NewEventBus(), eng, "", nil, kb, nil)
+
+	// Step 1: dispatch phase-1. This records LastDispatch{model: DefaultModel}.
+	res1, err := callNextAction(t, handler, workspace)
+	if err != nil || res1.IsError {
+		t.Fatalf("step 1: %v / %s", err, textContent(res1))
+	}
+	var action1 orchestrator.Action
+	if err := json.Unmarshal([]byte(textContent(res1)), &action1); err != nil {
+		t.Fatalf("step 1 unmarshal: %v", err)
+	}
+	if action1.Type != orchestrator.ActionSpawnAgent || action1.Model == "" {
+		t.Fatalf("step 1: expected spawn_agent with a model, got type=%q model=%q", action1.Type, action1.Model)
+	}
+
+	// Confirm LastDispatch was persisted.
+	s1, err := state.ReadState(workspace)
+	if err != nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if s1.LastDispatch == nil || s1.LastDispatch.Model != action1.Model {
+		t.Fatalf("LastDispatch not persisted with dispatched model; got %+v", s1.LastDispatch)
+	}
+
+	// Simulate the agent writing its artifact.
+	if err := os.WriteFile(filepath.Join(workspace, "analysis.md"), []byte("# Analysis\n"), 0o600); err != nil {
+		t.Fatalf("write analysis.md: %v", err)
+	}
+
+	// Step 2: report completion WITHOUT previous_model (empty). The engine must
+	// auto-carry the dispatched model into the phase-log entry for phase-1.
+	res2, err := callNextActionWithPrev(t, handler, workspace, 1500, 3000, "", false, true)
+	if err != nil || res2.IsError {
+		t.Fatalf("step 2: %v / %s", err, textContent(res2))
+	}
+
+	s2, err := state.ReadState(workspace)
+	if err != nil {
+		t.Fatalf("ReadState after step 2: %v", err)
+	}
+	var phaseOne *state.PhaseLogEntry
+	for i := range s2.PhaseLog {
+		if s2.PhaseLog[i].Phase == state.PhaseOne {
+			phaseOne = &s2.PhaseLog[i]
+			break
+		}
+	}
+	if phaseOne == nil {
+		t.Fatalf("phase-1 not found in phaseLog: %+v", s2.PhaseLog)
+	}
+	if phaseOne.Model != action1.Model {
+		t.Errorf("phase-1 model = %q, want auto-carried %q (orchestrator omitted previous_model)", phaseOne.Model, action1.Model)
+	}
+}
+
 func TestIntegration_P5_PreviousResultMerge(t *testing.T) {
 	t.Parallel()
 

--- a/mcp-server/internal/handler/tools/pipeline_next_action.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/orchestrator"
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/state"
+	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/analytics"
 	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/history"
 	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/profile"
 	"github.com/hiromaily/claude-forge/mcp-server/internal/intelligence/prompt"
@@ -80,12 +81,13 @@ type reportResultEmbedded struct {
 // checkpoint; the orchestrator should call pipeline_next_action again immediately.
 type nextActionResponse struct {
 	orchestrator.Action
-	Warning            string                `json:"warning,omitempty"`
-	DisplayMessage     string                `json:"display_message,omitempty"`
-	ReportResult       *reportResultEmbedded `json:"report_result,omitempty"`
-	CurrentPhase       string                `json:"current_phase,omitempty"`
-	CurrentPhaseStatus string                `json:"current_phase_status,omitempty"`
-	StillWaiting       bool                  `json:"still_waiting,omitempty"`
+	Warning            string                     `json:"warning,omitempty"`
+	DisplayMessage     string                     `json:"display_message,omitempty"`
+	ReportResult       *reportResultEmbedded      `json:"report_result,omitempty"`
+	CurrentPhase       string                     `json:"current_phase,omitempty"`
+	CurrentPhaseStatus string                     `json:"current_phase_status,omitempty"`
+	StillWaiting       bool                       `json:"still_waiting,omitempty"`
+	Analytics          *analytics.PipelineSummary `json:"analytics,omitempty"`
 }
 
 // parsePreviousResult extracts the optional previous_* parameters from the MCP request.
@@ -153,6 +155,22 @@ func PipelineNextActionHandler(
 			if stErr != nil {
 				return errorf("get state for report: %v", stErr)
 			}
+			// Auto-carry engine-authoritative dispatch metadata (#9): the model and
+			// setup-only flag were chosen by the engine when it emitted the last action,
+			// so prefer the persisted LastDispatch over orchestrator-threaded values.
+			// This frees the orchestrator from passing previous_model / previous_setup_only
+			// by hand; tokens and duration still come from the caller (only it observes the
+			// subagent's usage). When LastDispatch is absent (e.g. direct-state tests), the
+			// orchestrator-provided values are used as-is for backward compatibility.
+			model := prev.model
+			setupOnly := prev.setupOnly
+			if st.LastDispatch != nil {
+				if model == "" {
+					model = st.LastDispatch.Model
+				}
+				setupOnly = st.LastDispatch.SetupOnly
+			}
+
 			// Guard: skip reportResultCore for non-reportable phases.
 			if st.CurrentPhase != "setup" && st.CurrentPhase != "completed" {
 				rIn := reportResultInput{
@@ -160,15 +178,15 @@ func PipelineNextActionHandler(
 					phase:      st.CurrentPhase,
 					tokensUsed: prev.tokensUsed,
 					durationMs: prev.durationMs,
-					model:      prev.model,
-					setupOnly:  prev.setupOnly,
+					model:      model,
+					setupOnly:  setupOnly,
 				}
 				outcome, rErr := reportResultCore(sm2, kb, rIn)
 				if rErr != nil {
 					return errorf("report_result: %v", rErr)
 				}
 				// Publish action-complete for the finished agent/exec step.
-				publishEventWithDetail(bus, nil, "action-complete", st.CurrentPhase, st.SpecName, workspace, "completed", prev.model)
+				publishEventWithDetail(bus, nil, "action-complete", st.CurrentPhase, st.SpecName, workspace, "completed", model)
 
 				switch outcome.NextActionHint {
 				case "revision_required":
@@ -254,6 +272,22 @@ func PipelineNextActionHandler(
 						Action: orchestrator.NewDoneAction("pipeline abandoned at "+st.CurrentPhase, ""),
 					})
 				}
+			}
+		}
+
+		// P8b: post-to-source is a terminal "dynamic" checkpoint (options post/skip) that
+		// isCheckpointPhase does not cover. Without explicit handling the engine re-returns
+		// the same checkpoint forever, so the orchestrator can never reach done (improvement
+		// #7). Both "post" and "skip" complete the phase so the pipeline advances to
+		// final-commit → completed. The actual comment posting (for "post") is performed by
+		// the orchestrator before it calls back with the terminal response.
+		if userResponse == "post" || userResponse == "skip" {
+			if st, stErr := sm2.GetState(); stErr == nil && st.CurrentPhase == state.PhasePostToSource {
+				if completeErr := sm2.PhaseComplete(workspace, st.CurrentPhase); completeErr != nil {
+					return errorf("post-to-source %s: %v", userResponse, completeErr)
+				}
+				// Record the terminal resolution in PhaseLog for observability.
+				_ = sm2.PhaseLog(workspace, st.CurrentPhase, 0, 0, "checkpoint")
 			}
 		}
 
@@ -635,6 +669,12 @@ func PipelineNextActionHandler(
 			if startErr := sm2.PhaseStart(workspace, action.Phase); startErr != nil {
 				appendWarning(fmt.Sprintf("PhaseStart: %v", startErr))
 			}
+			// Persist engine-authoritative dispatch metadata so the next
+			// pipeline_next_action call can auto-carry previous_model /
+			// previous_setup_only without manual threading (improvement #9).
+			if ldErr := sm2.SetLastDispatch(workspace, action.Phase, action.Model, action.SetupOnly); ldErr != nil {
+				appendWarning(fmt.Sprintf("SetLastDispatch: %v", ldErr))
+			}
 		}
 
 		// Include current phase state in response for debugging and publish
@@ -650,6 +690,22 @@ func PipelineNextActionHandler(
 				publishEvent(bus, nil, "phase-start", action.Phase, st.SpecName, workspace, "in_progress")
 			case orchestrator.ActionDone:
 				publishEvent(bus, nil, "pipeline-complete", st.CurrentPhase, st.SpecName, workspace, "completed")
+			}
+		}
+
+		// Surface the cost/token spend so far at every human checkpoint so the user can
+		// weigh "continue vs stop" against the running cost, instead of only learning the
+		// total at the final analytics call (improvement #8). Best-effort: a collector
+		// error never blocks the checkpoint.
+		if action.Type == orchestrator.ActionCheckpoint {
+			if summary, sErr := analytics.NewCollector("").Collect(workspace); sErr == nil {
+				resp.Analytics = summary
+				if line := formatCheckpointCostLine(summary); line != "" {
+					if resp.DisplayMessage != "" {
+						resp.DisplayMessage += "\n"
+					}
+					resp.DisplayMessage += line
+				}
 			}
 		}
 
@@ -790,6 +846,15 @@ func enrichPrompt( //nolint:gocyclo // complexity is inherent in the multi-layer
 		histCtx = filterCurrentReviewFindings(workspace, histCtx)
 	}
 
+	// Narrow the "Common Review Findings" for a per-task impl-reviewer to findings
+	// relevant to the task under review, so unrelated findings (e.g. a SQL finding for
+	// a frontend-only task) are not attached to every Phase 6 review (improvement #2).
+	if action.Agent == "impl-reviewer" {
+		if taskKey := extractTaskNumber(action.OutputFile); taskKey != "" {
+			histCtx = filterFindingsForTask(st, taskKey, histCtx)
+		}
+	}
+
 	action.Prompt = prompt.BuildPrompt(action.Agent, agentInstructions, artifactsSection, profileStr, histCtx)
 
 	// Layer 5: checkpoint feedback injection.
@@ -860,6 +925,83 @@ func filterCurrentReviewFindings(workspace string, ctx prompt.HistoryContext) pr
 	ctx.CriticalPatterns = filteredCritical
 
 	return ctx
+}
+
+// filterFindingsForTask narrows the "Common Review Findings" injected for a per-task
+// impl-reviewer to those relevant to the task under review (improvement #2). Relevance is
+// a token overlap between the finding (its normalised pattern text + category) and the
+// task scope (its title + file paths). This drops findings that have nothing to do with
+// the task — e.g. a SQL finding attached to a frontend-only task — which previously
+// bloated every Phase 6 review prompt with the full unfiltered findings list.
+//
+// Fails open: when the task is unknown or has no usable scope tokens, the context is
+// returned unchanged so a thin task never silently loses all findings context.
+func filterFindingsForTask(st *state.State, taskKey string, ctx prompt.HistoryContext) prompt.HistoryContext {
+	task, ok := st.Tasks[taskKey]
+	if !ok {
+		return ctx
+	}
+
+	scope := map[string]bool{}
+	addTokens(scope, task.Title)
+	for _, f := range task.Files {
+		addTokens(scope, f)
+	}
+	if len(scope) == 0 {
+		return ctx
+	}
+
+	relevant := func(p history.PatternEntry) bool {
+		toks := map[string]bool{}
+		addTokens(toks, p.Pattern)
+		addTokens(toks, p.Category)
+		for tok := range toks {
+			if scope[tok] {
+				return true
+			}
+		}
+		return false
+	}
+
+	ctx.AllPatterns = filterPatternEntries(ctx.AllPatterns, relevant)
+	ctx.CriticalPatterns = filterPatternEntries(ctx.CriticalPatterns, relevant)
+	return ctx
+}
+
+// filterPatternEntries returns the entries for which keep returns true.
+func filterPatternEntries(entries []history.PatternEntry, keep func(history.PatternEntry) bool) []history.PatternEntry {
+	out := make([]history.PatternEntry, 0, len(entries))
+	for _, e := range entries {
+		if keep(e) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// findingsTokenStopwords are generic words that carry no relevance signal and would
+// otherwise cause spurious finding/task matches.
+//
+//nolint:gochecknoglobals // immutable lookup table
+var findingsTokenStopwords = map[string]bool{
+	"the": true, "and": true, "for": true, "with": true, "that": true, "this": true,
+	"from": true, "into": true, "code": true, "file": true, "files": true, "task": true,
+	"review": true, "should": true, "must": true, "use": true, "used": true, "using": true,
+	"add": true, "added": true, "missing": true, "error": true, "errors": true,
+}
+
+// addTokens splits s into lowercased alphanumeric tokens (length >= 3, excluding generic
+// stopwords) and records them in set. Path separators and punctuation are token boundaries,
+// so "frontend/app/adapters/user.ts" yields "frontend", "app", "adapters", "user".
+func addTokens(set map[string]bool, s string) {
+	for _, tok := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	}) {
+		if len(tok) < 3 || findingsTokenStopwords[tok] {
+			continue
+		}
+		set[tok] = true
+	}
 }
 
 // extractTaskNumber parses the task number from an output artifact filename.

--- a/mcp-server/internal/handler/tools/pipeline_next_action_test.go
+++ b/mcp-server/internal/handler/tools/pipeline_next_action_test.go
@@ -1288,6 +1288,67 @@ func callNextActionWithUserResponse(
 	return handler(t.Context(), req)
 }
 
+// TestPipelineNextAction_P8b_PostToSourceTerminal verifies improvement #7: a terminal
+// user_response of "post" or "skip" at the post-to-source checkpoint completes the phase
+// and lets the pipeline advance to done, rather than re-presenting the same checkpoint
+// (the still_waiting loop the orchestrator could never escape).
+func TestPipelineNextAction_P8b_PostToSourceTerminal(t *testing.T) {
+	t.Parallel()
+
+	for _, userResponse := range []string{"post", "skip"} {
+		t.Run(userResponse, func(t *testing.T) {
+			t.Parallel()
+
+			workspace, sm := initWorkspaceForNextAction(t, state.PhasePostToSource, func(s *state.State) error {
+				s.CurrentPhaseStatus = state.StatusAwaitingHuman
+				// SkipPr makes final-commit collapse to done, so the pipeline reaches
+				// completed deterministically once post-to-source is resolved.
+				s.SkipPr = true
+				return nil
+			})
+			_ = os.WriteFile(filepath.Join(workspace, state.ArtifactRequest), []byte("---\nsource_type: text\n---\n\ntask\n"), 0o600)
+			_ = os.WriteFile(filepath.Join(workspace, state.ArtifactSummary), []byte("# Summary\n"), 0o600)
+
+			eng := orchestrator.NewEngine("", "")
+			handler := PipelineNextActionHandler(sm, events.NewEventBus(), eng, "", nil, nil, nil)
+
+			result, err := callNextActionWithUserResponse(t, handler, workspace, userResponse)
+			if err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("handler returned MCP error: %s", textContent(result))
+			}
+
+			var resp nextActionResponse
+			if err := json.Unmarshal([]byte(textContent(result)), &resp); err != nil {
+				t.Fatalf("unmarshal: %v (raw: %s)", err, textContent(result))
+			}
+
+			// Must NOT re-return the post-to-source checkpoint (the bug).
+			if resp.Action.Type == orchestrator.ActionCheckpoint && resp.Action.Name == state.PhasePostToSource {
+				t.Fatalf("post-to-source re-returned the same checkpoint instead of advancing (still_waiting loop)")
+			}
+			if resp.StillWaiting {
+				t.Errorf("StillWaiting = true; terminal %q must not loop", userResponse)
+			}
+			// The pipeline should now be advancing to done.
+			if resp.Action.Type != orchestrator.ActionDone {
+				t.Errorf("action.Type = %q, want %q after terminal %q", resp.Action.Type, orchestrator.ActionDone, userResponse)
+			}
+
+			// State must have advanced beyond post-to-source.
+			s, loadErr := loadState(workspace)
+			if loadErr != nil {
+				t.Fatalf("loadState: %v", loadErr)
+			}
+			if s.CurrentPhase == state.PhasePostToSource {
+				t.Errorf("CurrentPhase still %q; expected the phase to complete and advance", state.PhasePostToSource)
+			}
+		})
+	}
+}
+
 func TestPipelineNextAction_P8_CheckpointRevision(t *testing.T) {
 	t.Parallel()
 

--- a/mcp-server/internal/handler/tools/workspace_init.go
+++ b/mcp-server/internal/handler/tools/workspace_init.go
@@ -78,6 +78,10 @@ func initWorkspace(
 		return "", fmt.Errorf("write request.md: %w", err)
 	}
 
+	// Keep the host project's markdownlint runs quiet about forge's internal spec
+	// artifacts under .specs/ (improvement #10). Best-effort; never fails init.
+	ensureMarkdownlintIgnore(workspace)
+
 	return requestMD, nil
 }
 

--- a/mcp-server/internal/intelligence/history/patterns.go
+++ b/mcp-server/internal/intelligence/history/patterns.go
@@ -5,12 +5,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/hiromaily/claude-forge/mcp-server/internal/engine/orchestrator"
 )
+
+// maxStoredPatterns bounds patterns.json growth. When Accumulate pushes the store
+// past this size, the lowest-value entries are pruned so the "Common Review Findings"
+// context injected into prompts stays bounded rather than accumulating without limit
+// across many pipeline runs (improvement #2).
+const maxStoredPatterns = 200
 
 // PatternEntry is one accumulated finding pattern.
 type PatternEntry struct {
@@ -239,7 +246,48 @@ func (a *PatternAccumulator) Accumulate(findings []orchestrator.Finding, agent s
 		}
 	}
 
+	a.pruneLocked()
+
 	return a.persist()
+}
+
+// pruneLocked drops the lowest-value pattern entries when the store exceeds
+// maxStoredPatterns, keeping the highest-value prefix and rebuilding the bucket
+// index. Must be called with a.mu held (write lock). Value ranking keeps CRITICAL
+// over MINOR, then higher frequency, then more recently seen — so stale, rare,
+// low-severity findings are the first to age out (improvement #2).
+func (a *PatternAccumulator) pruneLocked() {
+	if len(a.patterns) <= maxStoredPatterns {
+		return
+	}
+
+	sort.SliceStable(a.patterns, func(i, j int) bool {
+		return patternMoreValuable(a.patterns[i], a.patterns[j])
+	})
+	a.patterns = a.patterns[:maxStoredPatterns]
+	a.rebuildIndexLocked()
+}
+
+// patternMoreValuable reports whether x should be retained ahead of y when pruning.
+func patternMoreValuable(x, y PatternEntry) bool {
+	xc, yc := x.Severity == "CRITICAL", y.Severity == "CRITICAL"
+	if xc != yc {
+		return xc // CRITICAL ranks above MINOR
+	}
+	if x.Frequency != y.Frequency {
+		return x.Frequency > y.Frequency
+	}
+	return x.LastSeen.After(y.LastSeen)
+}
+
+// rebuildIndexLocked recreates the category|severity → indices bucket map from the
+// current patterns slice. Must be called with a.mu held (write lock).
+func (a *PatternAccumulator) rebuildIndexLocked() {
+	a.patternIdx = make(map[string][]int, len(a.patterns))
+	for i, p := range a.patterns {
+		key := p.Category + "|" + p.Severity
+		a.patternIdx[key] = append(a.patternIdx[key], i)
+	}
 }
 
 // Query returns pattern entries filtered by agentFilter and severityFilter, capped to limit.
@@ -301,11 +349,7 @@ func (a *PatternAccumulator) Load() error {
 	a.totalReviewsAnalyzed = pf.TotalReviewsAnalyzed
 
 	// Rebuild the bucket index from the loaded patterns.
-	a.patternIdx = make(map[string][]int, len(a.patterns))
-	for i, p := range a.patterns {
-		key := p.Category + "|" + p.Severity
-		a.patternIdx[key] = append(a.patternIdx[key], i)
-	}
+	a.rebuildIndexLocked()
 
 	return nil
 }

--- a/mcp-server/internal/intelligence/history/patterns_test.go
+++ b/mcp-server/internal/intelligence/history/patterns_test.go
@@ -1,6 +1,8 @@
 package history_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -310,5 +312,68 @@ func TestPatternLoad_AbsentFile(t *testing.T) {
 
 	if len(acc.Entries()) != 0 {
 		t.Errorf("want 0 entries after Load on absent file, got %d", len(acc.Entries()))
+	}
+}
+
+// TestPatternAccumulate_CapsStoredPatterns verifies improvement #2: the stored
+// pattern set is bounded (maxStoredPatterns = 200). When the store exceeds the cap,
+// the lowest-value entries age out while all CRITICAL findings are retained.
+func TestPatternAccumulate_CapsStoredPatterns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Seed patterns.json directly (Load does not merge or prune) with 250 distinct
+	// entries: 50 CRITICAL and 200 MINOR.
+	pf := history.PatternsFile{
+		UpdatedAt:            base,
+		TotalReviewsAnalyzed: 1,
+	}
+	for i := range 50 {
+		pf.Patterns = append(pf.Patterns, history.PatternEntry{
+			Pattern: fmt.Sprintf("critical pattern number %d", i), Severity: "CRITICAL",
+			Frequency: 1, Category: "other", FirstSeen: base, LastSeen: base.Add(time.Duration(i) * time.Hour),
+		})
+	}
+	for i := range 200 {
+		pf.Patterns = append(pf.Patterns, history.PatternEntry{
+			Pattern: fmt.Sprintf("minor pattern number %d", i), Severity: "MINOR",
+			Frequency: 1, Category: "other", FirstSeen: base, LastSeen: base.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	data, err := json.MarshalIndent(pf, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "patterns.json"), data, 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	acc := history.NewPatternAccumulator(dir)
+	if err := acc.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(acc.Entries()); got != 250 {
+		t.Fatalf("after Load want 250 entries, got %d", got)
+	}
+
+	// Any Accumulate call triggers the prune. Use empty findings so no new patterns are added.
+	if err := acc.Accumulate(nil, "impl-reviewer", base); err != nil {
+		t.Fatalf("Accumulate: %v", err)
+	}
+
+	entries := acc.Entries()
+	if len(entries) != 200 {
+		t.Errorf("after prune want 200 entries (cap), got %d", len(entries))
+	}
+	criticals := 0
+	for _, e := range entries {
+		if e.Severity == "CRITICAL" {
+			criticals++
+		}
+	}
+	if criticals != 50 {
+		t.Errorf("prune dropped CRITICAL findings: want all 50 retained, got %d", criticals)
 	}
 }

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -57,9 +57,10 @@ Example: `/forge 20260401-effort-only-flow`
       (S, M, L — each with `skipped_phases` using the `label` field).
       Each option has a `recommended` boolean — mark the one where
       `recommended` is `true` as "(Recommended)".
-      If `needs_user_confirmation.estimate` is present, show its P50/P90 token and USD
-      figures (and `sample_size`) so the user knows roughly how heavy the run will be —
-      effort L in particular can be multi-hour and multi-dollar.
+      If `needs_user_confirmation.estimate_display` is non-empty, output it **verbatim**
+      alongside the options so the user can gauge how heavy the run will be (effort L can
+      be multi-hour and multi-dollar). The server pre-formats the P50/P90 figures — do not
+      reconstruct them from the raw `estimate` struct.
    2. **Branch decision**: based on `current_branch` and `is_main_branch` from the response:
       - If `is_main_branch` is true: inform the user a new branch will be created (no question needed).
       - If `is_main_branch` is false: ask whether to use the current branch or create a new one.
@@ -124,9 +125,10 @@ Repeat until done:
        `{workspace}/{action.output_file}` before calling `pipeline_next_action`.
        This ensures `pipeline_report_result` artifact validation always succeeds.
    - `checkpoint`: Present `action.present_to_user` to the user.
-     If the response includes `display_message` or `analytics`, show the running-cost
-     line (tokens / estimated USD / phases / retries so far) to the user alongside the
-     checkpoint prompt so they can weigh "continue vs stop" against the spend so far.
+     If `display_message` is non-empty, output it **verbatim** — the server already appends
+     the running-cost line (tokens / estimated USD / phases / retries so far) so the user can
+     weigh "continue vs stop" against the spend. Do not assemble that line yourself from the
+     raw `analytics` field.
      Mention that the Dashboard can be used to approve without terminal input.
      Then **immediately** call `mcp__forge-state__pipeline_next_action(workspace)`
      (no `user_response`, no `previous_*`). The server long-polls up to 50 s

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -171,20 +171,18 @@ Repeat until done:
      next `pipeline_next_action` call. Omit `previous_model` or pass it as an empty string.
      Also pass `previous_action_complete=true` (see Rules below).
    - `human_gate`: A task requires human action (e.g. merge an external PR, update dependencies).
-     Present `action.present_to_user` to the user using AskUserQuestion with `action.options`.
+     Present `action.present_to_user` to the user **verbatim** using AskUserQuestion with
+     `action.options`. The server already embeds any cross-repository flow (external PR → CI
+     watch → preview-pin → verify, plus a dependency-update skill pointer) into
+     `present_to_user` for external-repo tasks — render that guidance as-is and help the user
+     drive it; do not re-derive the steps here. Choosing **"done"** is the deterministic
+     close: the engine clears the gate, so only pick it once the external change is pinned
+     and building.
      - If the user chooses **"done"** or **"skip"**: call `pipeline_next_action` again
        with no `previous_*` parameters (no agent ran).
        The handler automatically marks the task as completed.
      - If the user chooses **"abandon"**: call `mcp__forge-state__abandon(workspace)`.
      Do NOT call `checkpoint` or `phase_complete` for human_gate actions.
-     - **Cross-repo gates**: when `action.present_to_user` contains cross-repository
-       guidance (the task depends on an external repo — e.g. proto/akupara-proto,
-       a dependency bump, or a preview pin), surface that flow to the user and help drive
-       it: open the external repo's PR, watch its CI, fetch the preview artifact (preview
-       branch / pre-release version / SHA), then pin it in this repository and verify the
-       build. If the target repository ships an `update-proto` (or equivalent
-       dependency-update) skill, invoke it for the merge-before-preview pattern. Keep the
-       gate open (`done`) only once the external change is pinned and building here.
    - `done`: Pipeline complete. Stop.
 
 ## Supported Flags

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -107,16 +107,17 @@ Repeat until done:
    - `spawn_agent`: If `action.display_message` is non-empty, output it verbatim.
      Then call Agent tool with `action.prompt`. Use `action.agent` as description.
      Record the tokens, duration, and model for the next `pipeline_next_action` call.
-     - If `action.parallel_task_ids` is non-empty: spawn one Agent call per task ID in
+     - If `action.parallel_tasks` is non-empty: spawn one Agent call per entry in
        parallel; wait for all to complete before calling `pipeline_next_action` again.
-       Each parallel agent works on a single task `<id>` from the list: it reads that
-       task's `impl-<id>.md` and writes its own per-task output file
-       (`impl-<id>.md` for the implementer phase, `review-<id>.md` for the Phase 6
-       reviewer). `action.output_file` is empty for a parallel batch, so apply the
-       artifact write fallback below **per task ID**: after each agent returns, if its
-       `{workspace}/<prefix>-<id>.md` is missing, Write that agent's response text there
-       before calling `pipeline_next_action`. `pipeline_report_result` reconciles all of
-       the per-task review verdicts in a single pass.
+       Each entry `t` is an explicit, server-computed contract — do **not** derive any
+       filename yourself:
+       - inputs = `action.input_files` (shared) + `t.input_files` (task-specific)
+       - output artifact = `t.output_file`
+       After each agent returns, apply the **artifact write fallback per entry**: if
+       `{workspace}/{t.output_file}` does not exist on disk, Write that agent's response
+       text there before calling `pipeline_next_action`. `pipeline_report_result`
+       reconciles all of the per-task verdicts in a single pass.
+       (`action.parallel_task_ids` still lists the same IDs in order for reference.)
      - **Artifact write fallback**: After the agent returns, if `action.output_file` is
        non-empty, check whether `{workspace}/{action.output_file}` exists on disk. If
        the file does **NOT** exist, the agent returned its output as text instead of

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -57,6 +57,9 @@ Example: `/forge 20260401-effort-only-flow`
       (S, M, L — each with `skipped_phases` using the `label` field).
       Each option has a `recommended` boolean — mark the one where
       `recommended` is `true` as "(Recommended)".
+      If `needs_user_confirmation.estimate` is present, show its P50/P90 token and USD
+      figures (and `sample_size`) so the user knows roughly how heavy the run will be —
+      effort L in particular can be multi-hour and multi-dollar.
    2. **Branch decision**: based on `current_branch` and `is_main_branch` from the response:
       - If `is_main_branch` is true: inform the user a new branch will be created (no question needed).
       - If `is_main_branch` is false: ask whether to use the current branch or create a new one.
@@ -83,10 +86,13 @@ Repeat until done:
 1. Call `mcp__forge-state__pipeline_next_action(workspace=<workspace>,
    previous_action_complete=true,
    previous_tokens=<tokens from last action>,
-   previous_duration_ms=<ms from last action>,
-   previous_model=<model from last action>,
-   previous_setup_only=<setup_only from last action>)`.
+   previous_duration_ms=<ms from last action>)`.
    On the very first call, omit the `previous_*` parameters.
+   `previous_model` and `previous_setup_only` are **optional** and auto-carried: the
+   engine records the model and setup-only flag of the action it dispatched and reuses
+   them, so you only need to report `previous_action_complete` plus the observed
+   `previous_tokens` / `previous_duration_ms`. You may still pass `previous_model`
+   explicitly to override (it wins when non-empty).
 
 2. If `result.report_result` is non-null:
    - If `result.report_result.next_action_hint == "revision_required"`:
@@ -102,6 +108,14 @@ Repeat until done:
      Record the tokens, duration, and model for the next `pipeline_next_action` call.
      - If `action.parallel_task_ids` is non-empty: spawn one Agent call per task ID in
        parallel; wait for all to complete before calling `pipeline_next_action` again.
+       Each parallel agent works on a single task `<id>` from the list: it reads that
+       task's `impl-<id>.md` and writes its own per-task output file
+       (`impl-<id>.md` for the implementer phase, `review-<id>.md` for the Phase 6
+       reviewer). `action.output_file` is empty for a parallel batch, so apply the
+       artifact write fallback below **per task ID**: after each agent returns, if its
+       `{workspace}/<prefix>-<id>.md` is missing, Write that agent's response text there
+       before calling `pipeline_next_action`. `pipeline_report_result` reconciles all of
+       the per-task review verdicts in a single pass.
      - **Artifact write fallback**: After the agent returns, if `action.output_file` is
        non-empty, check whether `{workspace}/{action.output_file}` exists on disk. If
        the file does **NOT** exist, the agent returned its output as text instead of
@@ -110,6 +124,9 @@ Repeat until done:
        `{workspace}/{action.output_file}` before calling `pipeline_next_action`.
        This ensures `pipeline_report_result` artifact validation always succeeds.
    - `checkpoint`: Present `action.present_to_user` to the user.
+     If the response includes `display_message` or `analytics`, show the running-cost
+     line (tokens / estimated USD / phases / retries so far) to the user alongside the
+     checkpoint prompt so they can weigh "continue vs stop" against the spend so far.
      Mention that the Dashboard can be used to approve without terminal input.
      Then **immediately** call `mcp__forge-state__pipeline_next_action(workspace)`
      (no `user_response`, no `previous_*`). The server long-polls up to 50 s
@@ -157,6 +174,14 @@ Repeat until done:
        The handler automatically marks the task as completed.
      - If the user chooses **"abandon"**: call `mcp__forge-state__abandon(workspace)`.
      Do NOT call `checkpoint` or `phase_complete` for human_gate actions.
+     - **Cross-repo gates**: when `action.present_to_user` contains cross-repository
+       guidance (the task depends on an external repo — e.g. proto/akupara-proto,
+       a dependency bump, or a preview pin), surface that flow to the user and help drive
+       it: open the external repo's PR, watch its CI, fetch the preview artifact (preview
+       branch / pre-release version / SHA), then pin it in this repository and verify the
+       build. If the target repository ships an `update-proto` (or equivalent
+       dependency-update) skill, invoke it for the merge-before-preview pattern. Keep the
+       gate open (`done`) only once the external change is pinned and building here.
    - `done`: Pipeline complete. Stop.
 
 ## Supported Flags

--- a/skills/forge/SKILL.md
+++ b/skills/forge/SKILL.md
@@ -110,7 +110,8 @@ Repeat until done:
      - If `action.parallel_tasks` is non-empty: spawn one Agent call per entry in
        parallel; wait for all to complete before calling `pipeline_next_action` again.
        Each entry `t` is an explicit, server-computed contract — do **not** derive any
-       filename yourself:
+       filename yourself. Instruct that agent to work on task `t.id` (still using
+       `action.prompt` as the base prompt), with:
        - inputs = `action.input_files` (shared) + `t.input_files` (task-specific)
        - output artifact = `t.output_file`
        After each agent returns, apply the **artifact write fallback per entry**: if
@@ -175,9 +176,9 @@ Repeat until done:
      `action.options`. The server already embeds any cross-repository flow (external PR → CI
      watch → preview-pin → verify, plus a dependency-update skill pointer) into
      `present_to_user` for external-repo tasks — render that guidance as-is and help the user
-     drive it; do not re-derive the steps here. Choosing **"done"** is the deterministic
-     close: the engine clears the gate, so only pick it once the external change is pinned
-     and building.
+     drive it; do not re-derive the steps here. Choosing **"done"** clears the gate (the
+     deterministic close); for a cross-repo task, only choose it once the external change is
+     pinned and building here.
      - If the user chooses **"done"** or **"skip"**: call `pipeline_next_action` again
        with no `previous_*` parameters (no agent ran).
        The handler automatically marks the task as completed.

--- a/template/sections/architecture/mcp-data-contracts.md
+++ b/template/sections/architecture/mcp-data-contracts.md
@@ -147,10 +147,15 @@ Returns `needs_user_confirmation` for the orchestrator to present to the user:
     "current_branch": "main",
     "is_main_branch": true,
     "enriched_request_body": "implement login feature",
-    "message": "Detected effort=\"M\". ..."
+    "message": "Detected effort=\"M\". ...",
+    "estimate_display": "  📊 Estimate (effort=M, 4 past run(s)): ~120,000 tokens / ~$1.80 (P50) · up to ~210,000 tokens / ~$3.15 (P90)"
   }
 }
 ```
+
+`estimate_display` is a pre-formatted, verbatim line (omitted when no history exists); the
+orchestrator outputs it as-is rather than re-deriving P50/P90 figures from the raw `estimate`
+struct, keeping the cost presentation deterministic. `message` stays purely procedural.
 
 ### Response — First Call with `--discuss` (text source only)
 
@@ -252,11 +257,32 @@ When `report_result` is non-null, the engine has recorded a phase result interna
   "phase": "phase-1",
   "input_files": ["request.md"],
   "output_file": "analysis.md",
-  "parallel_task_ids": null
+  "parallel_task_ids": null,
+  "parallel_tasks": null
 }
 ```
 
-The `prompt` field contains the **4-layer assembled prompt** (see below). When `parallel_task_ids` is non-empty, the orchestrator spawns one agent per task ID concurrently.
+The `prompt` field contains the **4-layer assembled prompt** (see below). For a parallel
+fanout, `parallel_tasks` carries the per-task contract the engine computed — each entry has
+`{ "id", "input_files", "output_file" }` — and the orchestrator spawns one agent per entry
+concurrently, using `output_file` for the artifact-write fallback. The orchestrator never
+derives the `<prefix>-<id>.md` filename itself. `parallel_task_ids` mirrors the same IDs in
+order for callers that only need the count. Both are `null` for a sequential spawn.
+
+```json
+{
+  "type": "spawn_agent",
+  "agent": "impl-reviewer",
+  "phase": "phase-6",
+  "input_files": ["tasks.md"],
+  "output_file": "",
+  "parallel_task_ids": ["1", "3"],
+  "parallel_tasks": [
+    { "id": "1", "input_files": ["impl-1.md"], "output_file": "review-1.md" },
+    { "id": "3", "input_files": ["impl-3.md"], "output_file": "review-3.md" }
+  ]
+}
+```
 
 #### `checkpoint` — Pause for human review
 

--- a/template/sections/ja/architecture/mcp-data-contracts.md
+++ b/template/sections/ja/architecture/mcp-data-contracts.md
@@ -147,10 +147,15 @@
     "current_branch": "main",
     "is_main_branch": true,
     "enriched_request_body": "implement login feature",
-    "message": "Detected effort=\"M\". ..."
+    "message": "Detected effort=\"M\". ...",
+    "estimate_display": "  📊 Estimate (effort=M, 4 past run(s)): ~120,000 tokens / ~$1.80 (P50) · up to ~210,000 tokens / ~$3.15 (P90)"
   }
 }
 ```
+
+`estimate_display` は整形済みの verbatim 行（履歴がない場合は省略）。オーケストレーターは生の
+`estimate` 構造体から P50/P90 を再計算せず、この行をそのまま出力することでコスト表示を決定論的に保つ。
+`message` は手続き的な内容のみを保持する。
 
 ### レスポンス — `--discuss` 付き1回目コール（テキストソースのみ）
 
@@ -236,11 +241,31 @@
   "phase": "phase-1",
   "input_files": ["request.md"],
   "output_file": "analysis.md",
-  "parallel_task_ids": null
+  "parallel_task_ids": null,
+  "parallel_tasks": null
 }
 ```
 
-`prompt` フィールドは **4層組み立てプロンプト**（後述）を含む。`parallel_task_ids` が空でない場合、オーケストレーターはタスクIDごとに1つのエージェントを並行起動する。
+`prompt` フィールドは **4層組み立てプロンプト**（後述）を含む。並行ファンアウトの場合、
+`parallel_tasks` がエンジンの算出した per-task 契約（各エントリは `{ "id", "input_files", "output_file" }`）を保持し、
+オーケストレーターはエントリごとに1つのエージェントを並行起動して `output_file` を artifact-write フォールバックに用いる。
+オーケストレーターは `<prefix>-<id>.md` のファイル名を自前で導出しない。`parallel_task_ids` は同じ ID を順序どおりに
+ミラーする（件数のみ必要な呼び出し元向け）。逐次起動ではどちらも `null`。
+
+```json
+{
+  "type": "spawn_agent",
+  "agent": "impl-reviewer",
+  "phase": "phase-6",
+  "input_files": ["tasks.md"],
+  "output_file": "",
+  "parallel_task_ids": ["1", "3"],
+  "parallel_tasks": [
+    { "id": "1", "input_files": ["impl-1.md"], "output_file": "review-1.md" },
+    { "id": "3", "input_files": ["impl-3.md"], "output_file": "review-3.md" }
+  ]
+}
+```
 
 #### `checkpoint` — 人間レビューのための一時停止
 


### PR DESCRIPTION
## 概要

DEA-676（deal-risk-dashboard）の本番運用ランで surface した claude-forge の engine / MCP / skill 改善 10 件をまとめて適用する。各項目はテスト付き。

## 変更内容（#1–#10）

| # | 内容 |
|---|---|
| #1 | **Phase 6 レビュー並列化** — `handlePhaseSix` が独立タスクのレビューを `NewParallelSpawnAction` で fan-out。SKILL.md に per-task `review-<id>.md` fallback を追記 |
| #2 | **「Common Review Findings」の上限+スコープ化** — patterns.json を 200 件上限（value-ranked aging）に。impl-reviewer の findings をタスク関連トークンに絞り込み |
| #3 | **動的ブランチ名** — verifier.md を `{branch}` placeholder 化。init が request 内容からブランチ種別を分類（`DeriveBranchNameFromContent`） |
| #4 | **外部 issue 本文の request.md 永続化** — issue title+body を `enriched_request_body` に echo し、confirmation 往復後も要件が残るように |
| #5 | **Cross-repo ヒューマンゲート** — 外部リポジトリの PR→CI→preview-pin ガイダンスと dependency-update skill ポインタを注入。architect.md が design で cross-repo 依存をフラグ |
| #6 | **Verifier 成果物書き出し** — verifier.md の Output Format で named artifact ファイルへの書き出しを必須化（forge の MANDATORY-write injection と整合） |
| #7 | **post-to-source の terminal 遷移** — post/skip が phase を complete し `done` へ遷移（`still_waiting` ループを解消） |
| #8 | **コスト/トークン可視化** — 各 checkpoint で running spend を表示、effort 選択時に P50/P90 推定を表示 |
| #9 | **usage メタデータの自動引き継ぎ** — engine が `LastDispatch`（model, setup_only）を永続化し、orchestrator が `previous_model` / `previous_setup_only` を手動で渡さなくて済むように |
| #10 | **markdownlint ノイズ削減** — init が repo-root `.markdownlintignore`（`.specs/` 除外）を冪等に書き出す |

## テスト

- 各項目に対応する `*_test.go` を追加（actions / engine / display / findings_filter / markdownlint_ignore / pipeline_* / patterns）
- 22 ファイル変更 / +1113 -73

🤖 Generated with [Claude Code](https://claude.com/claude-code)---

## 追記: 決定論アーキテクチャ・フォローアップ (A/B/C)

「MCP server による決定論的挙動」を最重要指針とする観点で、上記 #1–#10 のうち SKILL.md 側に整形・制御フローを戻してしまっていた箇所をサーバへ寄せ直した。各コミットはテスト付き・`go test ./...` / `golangci-lint` クリーン（新規 issue なし）。

| | 内容 | 効果 |
|---|---|---|
| **A** | コスト/見積もりの整形をサーバへ集約（`estimate_display` を verbatim 出力、checkpoint の running-cost も既存の `display_message` を verbatim 化）。SKILL.md から「生 struct/analytics を LLM が整形」prose を排除 | P50/P90/USD の表示が再現可能に |
| **B** | parallel fanout を typed 化：`parallel_tasks[{id,input_files,output_file}]` をエンジンが算出。SKILL.md の `review-<id>.md` prose 導出を撤廃し、orchestrator は機械的に反復 | per-task I/O が決定論的に |
| **C** | cross-repo human_gate 手順の二重定義を解消。`present_to_user`（サーバ生成）を single source とし、gate の close 条件もサーバ guidance に明示 | 制御フローがエンジン側に一本化 |

ドキュメントは SSOT テンプレート (`template/sections/architecture/`) を編集し `make docs` で `ARCHITECTURE.md` を再生成済み。